### PR TITLE
Fix death banner centering and add fade-in effect

### DIFF
--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -6,9 +6,10 @@
 module Plunder.Guest(guest) where
 
 import           Control.Lens
-import           Control.Monad                   (void)
+import           Control.Monad                   (forM_, void)
 import           Control.Monad.Reader            (MonadReader (..))
 import           Control.Monad.Trans.Random.Lazy
+import           Data.Word                       (Word8)
 import           Plunder.Render.Layer
 import           Reflex
 import           Reflex.SDL2 hiding (Playing) -- avoid clash with SDL.Audio.Playing
@@ -36,14 +37,14 @@ guest = mdo
   font <- defaultFont
   bannerFont <- bigFont
 
-  gameState <- mkGameState shopEvt
+  (gameState, alphaDyn) <- mkGameState shopEvt
   renderState font gameState
   shopEvt <- renderShop font
     (view game_shop <$> gameState)
     (view (game_player_inventory . inventory_money) <$> gameState)
     (isJust . findFreeAdjacent <$> gameState)
   renderInventory font (view game_inventory_open <$> gameState) (view (game_player_inventory . inventroy_item) <$> gameState)
-  renderBanner bannerFont (view game_phase <$> gameState)
+  renderBanner bannerFont (view game_phase <$> gameState) alphaDyn
   pure ()
 
 
@@ -52,7 +53,7 @@ makeRandomNT :: forall m a . MonadIO m => m (RandTNT a)
 makeRandomNT =
   newStdGen <&> \stdgen -> MkRandTNT (\inner -> fst <$> runRandT inner stdgen)
 
-mkGameState :: forall t m . ReflexSDL2 t m => Event t ShopAction -> m (Dynamic t GameState)
+mkGameState :: forall t m . ReflexSDL2 t m => Event t ShopAction -> m (Dynamic t GameState, Dynamic t Word8)
 mkGameState shopActions = do
 
   -- figured these out with getAnySDLEvent and see which needed to redraw
@@ -64,6 +65,8 @@ mkGameState shopActions = do
 
   -- External trigger: fired from IO after the banner timer expires
   (resetEvt, fireReset) <- newTriggerEvent
+  -- External trigger: fade-in alpha updates fired from IO
+  (alphaEvt, fireAlpha) <- newTriggerEvent
 
   let leftClickEvts :: Event t MouseButtonEventData
       leftClickEvts = ffilter (has (mouseButtons . leftClick)) mouseButtonEvt
@@ -92,14 +95,21 @@ mkGameState shopActions = do
   ntDyn <- holdView makeRandomNT $ makeRandomNT <$ events
   state <- accumDyn updateState initialState ((,) <$> current ntDyn <@> events)
 
-  -- When the phase *transitions* into a game-over state, start a 5-second
-  -- timer then fire ResetGame to restore initial state.
   phaseDyn <- holdUniqDyn (view game_phase <$> state)
+
+  -- Fade-in alpha: step from 0→220 over 1 s (20 × 50 ms), then hold 4 s and reset.
+  alphaDyn <- holdDyn 0 $ leftmost
+    [ alphaEvt
+    , 0 <$ ffilter (== Playing) (updated phaseDyn)
+    ]
   performEvent_ $ ffor (ffilter (/= Playing) (updated phaseDyn)) $ \_ ->
     liftIO $ void $ forkIO $ do
-      threadDelay 5000000
+      forM_ [1..20 :: Int] $ \i -> do
+        threadDelay 50000           -- 50 ms per step
+        fireAlpha (fromIntegral (i * 11) `min` 220)
+      threadDelay 4000000           -- hold for 4 s then reset
       fireReset ResetGame
 
   performEvent_ $ ffor (describeState <$> updated state) $ liftIO . print
 
-  pure state
+  pure (state, alphaDyn)

--- a/src/Plunder/Render/Banner.hs
+++ b/src/Plunder/Render/Banner.hs
@@ -4,9 +4,9 @@
 module Plunder.Render.Banner(renderBanner) where
 
 import           Control.Lens
-import           Control.Monad
 import           Control.Monad.Reader (MonadReader (..))
-import           Data.Text            (Text)
+import           Data.Word            (Word8)
+import           Foreign.C.Types      (CInt)
 import           Plunder.Render.Color
 import           Plunder.Render.Font
 import           Plunder.Render.Image
@@ -16,35 +16,50 @@ import           Plunder.State        (GamePhase (..))
 import           Reflex
 import           Reflex.SDL2 hiding (Playing) -- avoid clash with SDL.Audio.Playing
 
+screenW, screenH :: CInt
+screenW = 640
+screenH = 480
+
+bannerW, bannerH :: CInt
+bannerW = 500
+bannerH = 110
+
+bannerRect :: Rectangle CInt
+bannerRect =
+  Rectangle (P $ V2 ((screenW - bannerW) `div` 2) ((screenH - bannerH) `div` 2))
+            (V2 bannerW bannerH)
+
+-- Horizontal centre of screen; surfaceToSettings handles the x offset.
+textPos :: Point V2 CInt
+textPos = P $ V2 (screenW `div` 2) (screenH `div` 2)
+
+msgStyle :: Style
+msgStyle = defaultStyle
+  & styleColorLens           .~ V4 220 50 50 255
+  & styleHorizontalAlignLens .~ Center
+
 -- | Render a full-width banner overlay for game-over / victory states.
+--   alphaDyn drives a fade-in (0 = transparent, 255 = fully opaque).
 --   Call this last in the render pipeline so it sits on top of everything.
 renderBanner
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
   => MonadReader Renderer m
-  => Font -> Dynamic t GamePhase -> m ()
-renderBanner font phaseDyn = do
+  => Font -> Dynamic t GamePhase -> Dynamic t Word8 -> m ()
+renderBanner font phaseDyn alphaDyn = do
   renderer <- ask
-  commitLayer $ renderBackground renderer <$> phaseDyn
-  void $ image =<< holdDyn Nothing =<< dynView (renderMessage font <$> phaseDyn)
-
-renderBackground :: MonadIO m => Renderer -> GamePhase -> m ()
-renderBackground renderer phase = case phase of
-  Playing -> pure ()
-  _ -> do
-    setDrawColor renderer $ V4 20 20 20 255
-    fillRect renderer (Just (Rectangle (P $ V2 50 190) (V2 500 110)))
-
-renderMessage
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> GamePhase -> m (Maybe ImageSettings)
-renderMessage _ Playing = pure Nothing
-renderMessage font phase = Just <$> renderText font style (P $ V2 300 230) msg
-  where
-    msg :: Text
-    msg = case phase of
-      YouDied       -> "YOU DIED"
-      YouVictorious -> "YOU ARE VICTORIOUS"
-    style = defaultStyle
-      & styleColorLens           .~ V4 220 50 50 255
-      & styleHorizontalAlignLens .~ Center
+  -- Pre-allocate text textures once; never recreated per frame.
+  diedImg <- surfaceToSettings <$> allocateText font msgStyle "YOU DIED"          <*> pure textPos
+  victImg <- surfaceToSettings <$> allocateText font msgStyle "YOU ARE VICTORIOUS" <*> pure textPos
+  let combined = (,) <$> phaseDyn <*> alphaDyn
+  commitLayer $ ffor combined $ \(phase, alpha) -> case phase of
+    Playing -> pure ()
+    _ -> do
+      let img = case phase of
+            YouDied       -> diedImg
+            _             -> victImg
+          tex = _image_content img
+      setDrawColor renderer (V4 20 20 20 alpha)
+      fillRect renderer (Just bannerRect)
+      textureAlphaMod tex $= alpha
+      copy renderer tex Nothing (Just $ img ^. image_position)


### PR DESCRIPTION
## Summary
- Fix centering of death banner text
- Add fade-in effect to death screen

## Test plan
- [ ] Run game and trigger death, verify banner is centered
- [ ] Verify fade-in animation plays on death screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)