### PR TITLE
Restore fade-in effect on death/victory banner

### DIFF
--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -6,8 +6,9 @@
 module Plunder.Guest(guest) where
 
 import           Control.Lens
-import           Control.Monad                   (void)
+import           Control.Monad                   (forM_, void)
 import           Control.Monad.Reader            (MonadReader (..))
+import           Data.Word                       (Word8)
 import           Foreign.C.Types                 (CInt)
 import           Control.Monad.Trans.Random.Lazy
 import           Plunder.Render.Layer
@@ -37,14 +38,14 @@ guest = mdo
   font <- defaultFont
   bannerFont <- bigFont
 
-  (gameState, winSizeDyn) <- mkGameState shopEvt
+  (gameState, alphaDyn, winSizeDyn) <- mkGameState shopEvt
   renderState font gameState
   shopEvt <- renderShop font
     (view game_shop <$> gameState)
     (view (game_player_inventory . inventory_money) <$> gameState)
     (isJust . findFreeAdjacent <$> gameState)
   renderInventory font (view game_inventory_open <$> gameState) (view (game_player_inventory . inventroy_item) <$> gameState)
-  renderBanner bannerFont (view game_phase <$> gameState) winSizeDyn
+  renderBanner bannerFont (view game_phase <$> gameState) alphaDyn winSizeDyn
   pure ()
 
 
@@ -53,7 +54,7 @@ makeRandomNT :: forall m a . MonadIO m => m (RandTNT a)
 makeRandomNT =
   newStdGen <&> \stdgen -> MkRandTNT (\inner -> fst <$> runRandT inner stdgen)
 
-mkGameState :: forall t m . ReflexSDL2 t m => Event t ShopAction -> m (Dynamic t GameState, Dynamic t (V2 CInt))
+mkGameState :: forall t m . ReflexSDL2 t m => Event t ShopAction -> m (Dynamic t GameState, Dynamic t Word8, Dynamic t (V2 CInt))
 mkGameState shopActions = do
 
   -- figured these out with getAnySDLEvent and see which needed to redraw
@@ -63,8 +64,9 @@ mkGameState shopActions = do
   mouseButtonEvt <- getMouseButtonEvent
   keyboardEvt <- getKeyboardEvent
 
-  -- External trigger: fired from IO after the banner timer expires
+  -- External triggers: fired from IO after the banner timer expires / for fade steps
   (resetEvt, fireReset) <- newTriggerEvent
+  (alphaEvt, fireAlpha) <- newTriggerEvent
 
   let leftClickEvts :: Event t MouseButtonEventData
       leftClickEvts = ffilter (has (mouseButtons . leftClick)) mouseButtonEvt
@@ -93,12 +95,20 @@ mkGameState shopActions = do
   ntDyn <- holdView makeRandomNT $ makeRandomNT <$ events
   state <- accumDyn updateState initialState ((,) <$> current ntDyn <@> events)
 
-  -- When the phase *transitions* into a game-over state, start a 5-second
-  -- timer then fire ResetGame to restore initial state.
   phaseDyn <- holdUniqDyn (view game_phase <$> state)
+
+  -- Fade-in alpha: step from 0→220 over 1 s (20 × 50 ms), then hold 4 s and reset.
+  alphaDyn <- holdDyn 0 $ leftmost
+    [ alphaEvt
+    , 0 <$ ffilter (== Playing) (updated phaseDyn)
+    ]
+  -- When the phase transitions into a game-over state, animate the fade then reset.
   performEvent_ $ ffor (ffilter (/= Playing) (updated phaseDyn)) $ \_ ->
     liftIO $ void $ forkIO $ do
-      threadDelay 5000000
+      forM_ [1..20 :: Int] $ \i -> do
+        threadDelay 50000           -- 50 ms per step
+        fireAlpha (fromIntegral (i * 11) `min` 220)
+      threadDelay 4000000           -- hold for 4 s then reset
       fireReset ResetGame
 
   winSizeDyn <- holdDyn (V2 640 480) $
@@ -106,4 +116,4 @@ mkGameState shopActions = do
 
   performEvent_ $ ffor (describeState <$> updated state) $ liftIO . print
 
-  pure (state, winSizeDyn)
+  pure (state, alphaDyn, winSizeDyn)

--- a/src/Plunder/Render/Banner.hs
+++ b/src/Plunder/Render/Banner.hs
@@ -18,7 +18,7 @@ import           Reflex.SDL2 hiding (Playing) -- avoid clash with SDL.Audio.Play
 
 bannerW, bannerH :: CInt
 bannerW = 500
-bannerH = 110
+bannerH = 140
 
 msgStyle :: Style
 msgStyle = defaultStyle

--- a/src/Plunder/Render/Banner.hs
+++ b/src/Plunder/Render/Banner.hs
@@ -4,9 +4,8 @@
 module Plunder.Render.Banner(renderBanner) where
 
 import           Control.Lens
-import           Control.Monad
 import           Control.Monad.Reader (MonadReader (..))
-import           Data.Text            (Text)
+import           Data.Word            (Word8)
 import           Foreign.C.Types      (CInt)
 import           Plunder.Render.Color
 import           Plunder.Render.Font
@@ -21,7 +20,13 @@ bannerW, bannerH :: CInt
 bannerW = 500
 bannerH = 110
 
+msgStyle :: Style
+msgStyle = defaultStyle
+  & styleColorLens           .~ V4 220 50 50 255
+  & styleHorizontalAlignLens .~ Center
+
 -- | Render a full-width banner overlay for game-over / victory states.
+--   alphaDyn drives a fade-in (0 = transparent, 255 = fully opaque).
 --   winSizeDyn carries the current window dimensions so the banner
 --   stays centred even after the user resizes the window.
 --   Call this last in the render pipeline so it sits on top of everything.
@@ -29,33 +34,26 @@ renderBanner
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
   => MonadReader Renderer m
-  => Font -> Dynamic t GamePhase -> Dynamic t (V2 CInt) -> m ()
-renderBanner font phaseDyn winSizeDyn = do
+  => Font -> Dynamic t GamePhase -> Dynamic t Word8 -> Dynamic t (V2 CInt) -> m ()
+renderBanner font phaseDyn alphaDyn winSizeDyn = do
   renderer <- ask
-  let combined = (,) <$> phaseDyn <*> winSizeDyn
-  commitLayer $ renderBackground renderer <$> combined
-  void $ image =<< holdDyn Nothing =<< dynView (renderMessage font winSizeDyn <$> phaseDyn)
-
-renderBackground :: MonadIO m => Renderer -> (GamePhase, V2 CInt) -> m ()
-renderBackground renderer (phase, V2 w h) = case phase of
-  Playing -> pure ()
-  _ -> do
-    setDrawColor renderer $ V4 20 20 20 255
-    fillRect renderer (Just (Rectangle (P $ V2 ((w - bannerW) `div` 2) ((h - bannerH) `div` 2))
-                                       (V2 bannerW bannerH)))
-
-renderMessage
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Dynamic t (V2 CInt) -> GamePhase -> m (Maybe ImageSettings)
-renderMessage _ _ Playing = pure Nothing
-renderMessage font winSizeDyn phase = do
-  V2 w h <- sample (current winSizeDyn)
-  Just <$> renderText font style (P $ V2 (w `div` 2) (h `div` 2)) msg
-  where
-    msg :: Text
-    msg = case phase of
-      YouDied       -> "YOU DIED"
-      YouVictorious -> "YOU ARE VICTORIOUS"
-    style = defaultStyle
-      & styleColorLens           .~ V4 220 50 50 255
-      & styleHorizontalAlignLens .~ Center
+  -- Pre-allocate text textures once; never recreated per frame.
+  diedImg <- allocateText font msgStyle "YOU DIED"
+  victImg <- allocateText font msgStyle "YOU ARE VICTORIOUS"
+  let combined = (,,) <$> phaseDyn <*> alphaDyn <*> winSizeDyn
+  commitLayer $ ffor combined $ \(phase, alpha, V2 w h) -> case phase of
+    Playing -> pure ()
+    _ -> do
+      let surf = case phase of
+                   YouDied       -> diedImg
+                   YouVictorious -> victImg
+          centerPt = P $ V2 (w `div` 2) (h `div` 2)
+          img      = surfaceToSettings surf centerPt
+          tex      = _image_content img
+          bannerRect = Rectangle
+            (P $ V2 ((w - bannerW) `div` 2) ((h - bannerH) `div` 2))
+            (V2 bannerW bannerH)
+      setDrawColor renderer (V4 20 20 20 alpha)
+      fillRect renderer (Just bannerRect)
+      textureAlphaMod tex $= alpha
+      copy renderer tex Nothing (Just $ img ^. image_position)


### PR DESCRIPTION
## Summary
- PR #16 (dynamic window centering) branched from `add-fren` before PR #15 (fade-in) merged, so the merge clobbered `Banner.hs` and lost the fade
- Restores `alphaDyn :: Dynamic t Word8` in `mkGameState`: steps 0→220 over 1 s (20 × 50 ms ticks via `forkIO`), resets to 0 when phase returns to `Playing`
- `renderBanner` now takes both `alphaDyn` and `winSizeDyn`, applying alpha to both the background fill and the text texture

## Test plan
- [ ] Trigger death/victory — banner should fade in over ~1 s then disappear after 4 s
- [ ] Resize window — banner should still be centred

🤖 Generated with [Claude Code](https://claude.com/claude-code)