### PR TITLE
Turn-based movement, queued attacks/purchases, and terrain

### DIFF
--- a/game13.cabal
+++ b/game13.cabal
@@ -39,6 +39,7 @@ library
       Plunder.Render.Image
       Plunder.Render.Arrow
       Plunder.Render.Banner
+      Plunder.Render.Terrain
       Plunder.Render.Inventory
       Plunder.Render.Layer
       Plunder.Render.Shop

--- a/src/Plunder/Grid.hs
+++ b/src/Plunder/Grid.hs
@@ -16,9 +16,11 @@ module Plunder.Grid
   , tile_axial
   , tile_content
   , tile_background
+  , tile_terrain
   , tile_coordinate
   , TileContent(..)
   , Background(..)
+  , Terrain(..)
   , Tile
   , _Player
   , _Enemy
@@ -26,6 +28,9 @@ module Plunder.Grid
   , _House
   , _Shop
   , _BurnedHouse
+  , _Land
+  , _Water
+  , _Mountains
   , contentFold
   , mkGrid
   , defUnit
@@ -66,12 +71,19 @@ data Background = Blood
                 | BurnedShop -- TODO make image
   deriving (Show, Generic, Eq)
 
+data Terrain = Land
+             | Water
+             | Mountains
+  deriving (Show, Generic, Eq)
+
 data Tile = MkTile
   { _tile_coordinate :: Axial
    -- | interactive layer (which can be destroyed)
   , _tile_content    :: Maybe TileContent
    -- | decorative layer (for destroyed things, blood bodies and ruins)
   , _tile_background :: Maybe Background
+   -- | terrain type; determines passability and appearance
+  , _tile_terrain    :: Terrain
   } deriving (Show, Generic, Eq)
 
 
@@ -80,6 +92,7 @@ makeLenses 'MkTile
 makeLenses ''TileContent
 makePrisms ''TileContent
 makePrisms ''Background
+makePrisms ''Terrain
 
 -- | A read only coordinate lens for 'Tile',
 --   within the module we can set but outside we can only read so it's
@@ -97,7 +110,7 @@ mkGrid begin end =
   q <- size
   r <- size
   let coordinate = MkAxial q r
-  pure $ (coordinate , MkTile coordinate Nothing Nothing)
+  pure (coordinate, MkTile coordinate Nothing Nothing Land)
   where
     size :: [Int]
     size = [begin .. end]
@@ -187,9 +200,14 @@ instance Arbitrary Axial where
   arbitrary = MkAxial <$> choose (0,6) <*> choose (0,6)
   shrink = genericShrink
 
+instance Arbitrary Terrain where
+  arbitrary = elements [Land, Water, Mountains]
+  shrink = genericShrink
+
 instance Arbitrary Tile where
-  arbitrary = MkTile <$> arbitrary <*>
-    frequency [(10, Just <$> arbitrary ), (5, pure Nothing)]
+  arbitrary = MkTile <$> arbitrary
+    <*> frequency [(10, Just <$> arbitrary), (5, pure Nothing)]
+    <*> arbitrary
     <*> arbitrary
   shrink = genericShrink
 

--- a/src/Plunder/Render.hs
+++ b/src/Plunder/Render.hs
@@ -22,6 +22,7 @@ import           Plunder.Render.Health
 import           Plunder.Render.Hexagon
 import           Plunder.Render.Image
 import           Plunder.Render.Layer
+import           Plunder.Render.Terrain
 import           Plunder.State
 import           Plunder.Render.Font
 
@@ -31,6 +32,11 @@ renderState :: ReflexSDL2 t m
   => Font ->  Dynamic t GameState -> m ()
 renderState font state = do
   renderer <- ask
+
+  -- Terrain fill is the very first (lowest) layer: coloured hexagons for
+  -- every coordinate in range, with Water used for anything outside the grid.
+  renderTerrain renderer (view game_board <$> state)
+
   vikingF <- renderImage <$> loadViking
   enemyF <- renderImage <$> loadEnemy
   loadBloodF <- renderImage <$> loadBlood

--- a/src/Plunder/Render/Terrain.hs
+++ b/src/Plunder/Render/Terrain.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Plunder.Render.Terrain
+  ( renderTerrain
+  ) where
+
+import qualified Data.Foldable        as Foldable
+import qualified Data.Map.Strict      as Map
+import qualified Data.Vector.Storable as S
+import           Control.Lens
+import           Data.Int             (Int16)
+import           Foreign.C.Types      (CInt)
+import           Plunder.Grid
+import           Plunder.Render.Layer
+import           Reflex
+import           Reflex.SDL2
+import           SDL.Primitive        (fillPolygon, Color)
+
+-- | RGBA colour for each terrain type.
+terrainToColor :: Terrain -> Color
+terrainToColor Land      = V4  86 168  86 255  -- grass green
+terrainToColor Water     = V4  65 105 225 255  -- royal blue
+terrainToColor Mountains = V4 148 128 115 255  -- stone grey
+
+-- | Axial range rendered as terrain (covers the visible screen and one-hex
+--   border on each side so that "outside the grid" shows as water).
+terrainCoords :: [Axial]
+terrainCoords = [MkAxial q r | q <- [-1 .. 7], r <- [-1 .. 7]]
+
+-- | Compute the six polygon corners of a pointy-top hexagon at the given
+--   axial coordinate.
+hexPolyPoints :: Axial -> (S.Vector Int16, S.Vector Int16)
+hexPolyPoints axial = (S.fromList xs, S.fromList ys)
+  where
+    P (V2 cx cy) = axialToPixel axial
+    -- Pointy-top hexagon corners at 330°, 30°, 90°, 150°, 210°, 270°.
+    cornerDegrees :: [Double]
+    cornerDegrees = [330, 30, 90, 150, 210, 270]
+    toCoord deg =
+      let rad = pi / 180.0 * deg
+          px  = cx + (floor (fromIntegral hexSize * cos rad) :: CInt)
+          py  = cy + (floor (fromIntegral hexSize * sin rad) :: CInt)
+      in (fromIntegral px :: Int16, fromIntegral py :: Int16)
+    corners = map toCoord cornerDegrees
+    xs = map fst corners
+    ys = map snd corners
+
+-- | Render terrain-filled hexagons for all coordinates in 'terrainCoords'.
+--   Coordinates absent from the grid are drawn with the Water colour so that
+--   the area beyond the map boundary looks like ocean.
+renderTerrain :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => Renderer
+  -> Dynamic t Grid
+  -> m ()
+renderTerrain renderer boardDyn =
+  commitLayer $ ffor boardDyn $ \board ->
+    Foldable.for_ terrainCoords $ \axial ->
+      let color = case Map.lookup axial board of
+                    Nothing   -> terrainToColor Water
+                    Just tile -> terrainToColor (tile ^. tile_terrain)
+          (xs, ys) = hexPolyPoints axial
+      in fillPolygon renderer xs ys color

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -55,7 +55,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set(Set)
 import qualified Data.Set as Set
-import Data.Maybe(listToMaybe)
+import Data.Maybe(listToMaybe, isJust)
 
 data GamePhase = Playing | YouDied | YouVictorious deriving (Show, Eq)
 
@@ -156,6 +156,7 @@ isAttack state' towards =
 isMove :: GameState -> Axial -> Bool
 isMove state' towards =
   has (mTraverseBoard towards . _Nothing) state'
+  && has (game_board . ix towards . tile_terrain . _Land) state'
 
 -- figures out if the tile we're moving towards is a neigbour of the
 -- selected tile, and verifies that hte selected tile is the player.
@@ -270,8 +271,9 @@ planPlayerMove state' towards = do
   selectedAxial <- state' ^. game_selected
   _player :: Unit <- state' ^? game_board . ix selectedAxial . tile_content . _Just . _Player
   let isShopTile = has (game_board . ix towards . tile_content . _Just . _Shop) state'
+      canTarget  = isJust (isAttack state' towards) || isMove state' towards
   guard $ towards == selectedAxial
-       || (towards `elem` neigbours selectedAxial && not isShopTile)
+       || (towards `elem` neigbours selectedAxial && not isShopTile && canTarget)
   pure (selectedAxial, towards)
 
 -- | Re-derive a walk or attack action at execution time so that plans that

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -187,6 +187,27 @@ spec = do
     result ^? game_board . ix (MkAxial 2 3) . tile_content . _Just . _Player . unit_hp
       `shouldBe` Just 10
 
+ describe "Terrain" $ do
+  let playerAxial = MkAxial 2 3
+      adjAxial    = MkAxial 2 4   -- adjacent empty tile in initial layout
+      selectedState = initialState & game_selected .~ Just playerAxial
+
+  it "Water tiles are not plannable" $ do
+    let waterState = selectedState
+          & game_board . ix adjAxial . tile_terrain .~ Water
+        result = runEvt (RightClick adjAxial) waterState
+    result ^. game_planned_moves `shouldBe` Map.empty
+
+  it "Mountain tiles are not plannable" $ do
+    let mtnState = selectedState
+          & game_board . ix adjAxial . tile_terrain .~ Mountains
+        result = runEvt (RightClick adjAxial) mtnState
+    result ^. game_planned_moves `shouldBe` Map.empty
+
+  it "Land tiles remain plannable" $ do
+    let result = runEvt (RightClick adjAxial) selectedState
+    result ^. game_planned_moves `shouldBe` Map.singleton playerAxial adjAxial
+
  describe "Turn-based movement" $ do
   -- Player starts at MkAxial 2 3; MkAxial 2 4 is an adjacent empty tile.
   let playerAxial = MkAxial 2 3


### PR DESCRIPTION
## Summary

- **Turn-based movement** — right-clicking an adjacent empty tile queues a planned move (stored as `Map Axial Axial`); right-clicking own tile cancels it. An orange arrow (new `Plunder.Render.Arrow` module) previews the planned move.
- **End Turn button** — bottom-right corner, tracks window size. On click: executes all queued moves, attacks, and pending purchases atomically.
- **Queued attacks** — right-clicking an adjacent enemy or house queues a planned attack (orange arrow) instead of resolving immediately; combat resolves on EndTurn.
- **Queued shop purchases** — buying from the shop records a pending purchase; a "Purchasing \<item\>" label appears above the buyer's tile. EndTurn applies it; queuing another move cancels it.
- **Terrain** — each tile has a `Terrain` field (`Land | Water | Mountains`). Mountains and Water are impassable. A new `Plunder.Render.Terrain` module renders filled hexagons as the lowest layer; out-of-bounds hexes render as Water (ocean border).

## Test plan

- [x] `cabal build` — no errors, no warnings
- [x] `cabal test` — 56 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)