### PR TITLE
Health potion usage, weapon equip, help screen

### DIFF
--- a/game13.cabal
+++ b/game13.cabal
@@ -35,6 +35,7 @@ library
       Plunder.Render.Color
       Plunder.Render.Font
       Plunder.Render.Health
+      Plunder.Render.Help
       Plunder.Render.Hexagon
       Plunder.Render.Image
       Plunder.Render.Arrow

--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -23,6 +23,7 @@ import Plunder.Render.Font(defaultFont, bigFont)
 import Plunder.Render.Shop
 import Plunder.Render.Inventory
 import Plunder.Render.Banner
+import Plunder.Render.Help
 import Plunder.Render.Text (defaultStyle, surfaceToSettings, allocateText, textSurfaceSize)
 import Plunder.Render.Image (image)
 import Data.Maybe (isJust)
@@ -39,6 +40,11 @@ guest = mdo
 
   font <- defaultFont
   bannerFont <- bigFont
+
+  anyMouseEvt <- getMouseButtonEvent
+  anyKeyEvt   <- getKeyboardEvent
+  helpOpenDyn <- holdDyn True $ False <$ leftmost [() <$ anyMouseEvt, () <$ anyKeyEvt]
+  renderHelp font helpOpenDyn
 
   (gameState, alphaDyn, winSizeDyn, fireEndTurn) <- mkGameState shopEvt inventoryClickEvt
   renderState font gameState

--- a/src/Plunder/Render/Help.hs
+++ b/src/Plunder/Render/Help.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DataKinds #-}
+
+module Plunder.Render.Help(renderHelp) where
+
+import           Control.Lens
+import           Control.Monad
+import           Control.Monad.Reader (MonadReader (..))
+import           Data.Text            (Text)
+import           Foreign.C.Types      (CInt)
+import           Plunder.Render.Color
+import           Plunder.Render.Font
+import           Plunder.Render.Image (ImageSettings (..), image_position)
+import           Plunder.Render.Layer
+import           Plunder.Render.Text
+import           Reflex
+import           Reflex.SDL2
+
+data LineStyle = Header | Body | Dim
+
+helpLines :: [(Text, LineStyle)]
+helpLines =
+  [ ("Controls",                          Header)
+  , (" ",                                 Body)
+  , ("Left click   select unit",          Body)
+  , ("Right click  plan move / attack",   Body)
+  , ("Right click  open nearby shop",     Body)
+  , ("Space        end turn",             Body)
+  , ("I            toggle inventory",     Body)
+  , ("Click item   use from inventory",   Body)
+  , (" ",                                 Body)
+  , ("Click or press any key to start",   Dim)
+  ]
+
+toStyle :: LineStyle -> Style
+toStyle Header = defaultStyle & styleColorLens .~ V4 0   0   0   255
+toStyle Body   = defaultStyle & styleColorLens .~ V4 40  40  40  255
+toStyle Dim    = defaultStyle & styleColorLens .~ V4 120 120 120 255
+
+bgW :: CInt
+bgW = 330
+
+bgH :: CInt
+bgH = 230
+
+bgX :: CInt
+bgX = (640 - bgW) `div` 2
+
+bgY :: CInt
+bgY = (480 - bgH) `div` 2
+
+lineH :: CInt
+lineH = 20
+
+textX :: CInt
+textX = bgX + 14
+
+textY :: Int -> CInt
+textY idx = bgY + 14 + fromIntegral idx * lineH
+
+renderHelp
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Dynamic t Bool -> m ()
+renderHelp font isOpen = do
+  renderer <- ask
+  surfaces <- forM helpLines $ \(text, ls) -> allocateText font (toStyle ls) text
+  commitLayer $ ffor isOpen $ \open -> when open $ do
+    setDrawColor renderer (V4 210 210 210 245)
+    fillRect renderer $ Just (Rectangle (P $ V2 bgX bgY) (V2 bgW bgH))
+    setDrawColor renderer (V4 0 0 0 255)
+    drawRect renderer $ Just (Rectangle (P $ V2 bgX bgY) (V2 bgW bgH))
+    forM_ (zip [0 ..] surfaces) $ \(idx, surf) ->
+      let img = surfaceToSettings surf (P $ V2 textX (textY idx))
+      in  copy renderer (_image_content img) Nothing (Just $ img ^. image_position)


### PR DESCRIPTION
## Summary
- Health potions usable from inventory: clicking marks player `DrinkingPotion`, then heals 1 HP/turn for 5 turns on EndTurn
- Weapon equip from inventory: clicking a weapon equips it, swapping old weapon back to inventory; works for friends too
- Controls help screen shown on game start, dismissed by any mouse/key press
- Health capped at maxHealth when healing
- Fixed: inventory clicks were swallowed by LeftClick event (event ordering fix)
- Fixed: item consumed without effect when no unit selected (falls back to first player on board)

## Test plan
- [x] `cabal build` — passes clean
- [x] `cabal test` — 75 examples, 0 failures
- [ ] Manually: launch game → help screen appears → click to dismiss → buy potion → open inventory → click potion → press Space 6x → HP rises for 5 turns
- [ ] Manually: buy a weapon → open inventory → click it → unit equips it; old weapon returns to inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)