### PR TITLE
Add terrain type to TOML level format

### DIFF
--- a/assets/levels/level1.toml
+++ b/assets/levels/level1.toml
@@ -57,3 +57,13 @@ hp = 10
 q = 1
 r = 6
 background = "blood"
+
+[[tiles]]
+q = 0
+r = 0
+terrain = "water"
+
+[[tiles]]
+q = 6
+r = 6
+terrain = "mountains"

--- a/src/Plunder/Level.hs
+++ b/src/Plunder/Level.hs
@@ -13,6 +13,7 @@ module Plunder.Level
   , tp_r
   , tp_content
   , tp_background
+  , tp_terrain
   , decodeLevel
   , decodeLevelFile
   , levelToToml
@@ -48,6 +49,7 @@ data TilePlacement = MkTilePlacement
   , _tp_r          :: Int
   , _tp_content    :: Maybe TileContentDef
   , _tp_background :: Maybe Background
+  , _tp_terrain    :: Maybe Terrain
   } deriving (Show, Eq)
 
 -- | A complete level definition.
@@ -95,6 +97,13 @@ backgroundFromText t = case T.toLower t of
   "burned-shop"  -> Just BurnedShop
   _              -> Nothing
 
+terrainFromText :: Text -> Maybe Terrain
+terrainFromText t = case T.toLower t of
+  "grass"     -> Just Land
+  "water"     -> Just Water
+  "mountains" -> Just Mountains
+  _           -> Nothing
+
 shopItemTypeFromText :: Text -> Maybe ShopItemType
 shopItemTypeFromText t = case T.toLower t of
   "health-potion" -> Just ShopHealthPotion
@@ -117,6 +126,13 @@ decodeBackground = do
   case backgroundFromText t of
     Just b  -> pure b
     Nothing -> fail "Expected background: blood, burned-house, or burned-shop"
+
+decodeTerrain :: Decoder Terrain
+decodeTerrain = do
+  t <- tomlDecoder @Text
+  case terrainFromText t of
+    Just tr -> pure tr
+    Nothing -> fail "Expected terrain: grass, water, or mountains"
 
 decodeShopItemType :: Decoder ShopItemType
 decodeShopItemType = do
@@ -162,6 +178,7 @@ instance DecodeTOML TilePlacement where
           pure $ Just $ ShopDef sc
         _ -> fail $ "Unknown content type: " <> T.unpack tag
     _tp_background <- getFieldOptWith decodeBackground "background"
+    _tp_terrain    <- getFieldOptWith decodeTerrain "terrain"
     pure MkTilePlacement{..}
 
 decodeLevelDecoder :: Decoder Level
@@ -194,6 +211,11 @@ backgroundToText Blood       = "blood"
 backgroundToText BurnedHouse = "burned-house"
 backgroundToText BurnedShop  = "burned-shop"
 
+terrainToText :: Terrain -> Text
+terrainToText Land      = "grass"
+terrainToText Water     = "water"
+terrainToText Mountains = "mountains"
+
 shopItemTypeToText :: ShopItemType -> Text
 shopItemTypeToText ShopHealthPotion = "health-potion"
 shopItemTypeToText ShopUnit         = "unit"
@@ -211,7 +233,7 @@ tilePlacementToToml tp = T.unlines $
   [ "[[tiles]]"
   , "q = " <> textShow (_tp_q tp)
   , "r = " <> textShow (_tp_r tp)
-  ] <> contentLines <> backgroundLines
+  ] <> contentLines <> backgroundLines <> terrainLines
   where
     contentLines :: [Text]
     contentLines = case _tp_content tp of
@@ -233,6 +255,10 @@ tilePlacementToToml tp = T.unlines $
     backgroundLines = case _tp_background tp of
       Nothing -> []
       Just bg -> ["background = \"" <> backgroundToText bg <> "\""]
+    terrainLines :: [Text]
+    terrainLines = case _tp_terrain tp of
+      Nothing -> []
+      Just tr -> ["terrain = \"" <> terrainToText tr <> "\""]
 
 -- | Render a Level to TOML text.
 levelToToml :: Level -> Text
@@ -257,16 +283,16 @@ defaultLevel = MkLevel
   , _level_grid_end   = 6
   , _level_money      = 0
   , _level_tiles =
-      [ MkTilePlacement 2 3 (Just (PlayerDef 10 (Just Axe))) Nothing
-      , MkTilePlacement 3 3 (Just (HouseDef 10)) Nothing
+      [ MkTilePlacement 2 3 (Just (PlayerDef 10 (Just Axe))) Nothing Nothing
+      , MkTilePlacement 3 3 (Just (HouseDef 10)) Nothing Nothing
       , MkTilePlacement 2 6 (Just (ShopDef (MkShopContent
           (Just (MkShopItem 4 ShopHealthPotion))
           (Just (MkShopItem 8 ShopUnit))
-          (Just (MkShopItem 5 (ShopWeapon Sword)))))) Nothing
-      , MkTilePlacement 4 5 (Just (EnemyDef 10 (Just Axe))) Nothing
-      , MkTilePlacement 4 4 (Just (EnemyDef 10 (Just Bow))) Nothing
-      , MkTilePlacement 4 3 (Just (EnemyDef 10 (Just Sword))) Nothing
-      , MkTilePlacement 0 6 (Just (EnemyDef 10 Nothing)) Nothing
-      , MkTilePlacement 1 6 Nothing (Just Blood)
+          (Just (MkShopItem 5 (ShopWeapon Sword)))))) Nothing Nothing
+      , MkTilePlacement 4 5 (Just (EnemyDef 10 (Just Axe))) Nothing Nothing
+      , MkTilePlacement 4 4 (Just (EnemyDef 10 (Just Bow))) Nothing Nothing
+      , MkTilePlacement 4 3 (Just (EnemyDef 10 (Just Sword))) Nothing Nothing
+      , MkTilePlacement 0 6 (Just (EnemyDef 10 Nothing)) Nothing Nothing
+      , MkTilePlacement 1 6 Nothing (Just Blood) Nothing
       ]
   }

--- a/src/Plunder/Level.hs
+++ b/src/Plunder/Level.hs
@@ -132,7 +132,7 @@ decodeTerrain = do
   t <- tomlDecoder @Text
   case terrainFromText t of
     Just tr -> pure tr
-    Nothing -> fail "Expected terrain: grass, water, or mountains"
+    Nothing -> fail $ "Unknown terrain: " <> T.unpack t <> ". Expected one of: grass, water, mountains"
 
 decodeShopItemType :: Decoder ShopItemType
 decodeShopItemType = do

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -165,6 +165,7 @@ levelToGameState lvl =
     applyPlacement tp g = g
       & maybe id (\c -> at axial . _Just . tile_content ?~ tileContentDefToContent c) (tp ^. tp_content)
       & maybe id (\b -> at axial . _Just . tile_background ?~ b) (tp ^. tp_background)
+      & maybe id (\t -> at axial . _Just . tile_terrain .~ t) (tp ^. tp_terrain)
       where
         axial :: Axial
         axial = MkAxial (tp ^. tp_q) (tp ^. tp_r)
@@ -180,12 +181,16 @@ gameStateToLevel begin end gs = MkLevel
   where
     tileToPlacement :: Tile -> Maybe TilePlacement
     tileToPlacement tile
-      | hasn't (tile_content . _Just) tile && hasn't (tile_background . _Just) tile = Nothing
+      | hasn't (tile_content . _Just) tile
+        && hasn't (tile_background . _Just) tile
+        && has (tile_terrain . _Land) tile
+        = Nothing
       | otherwise = Just $ MkTilePlacement
           { _tp_q          = tile ^. tile_coordinate . _q
           , _tp_r          = tile ^. tile_coordinate . _r
           , _tp_content    = tileContentToDef <$> tile ^. tile_content
           , _tp_background = tile ^. tile_background
+          , _tp_terrain    = if has (tile_terrain . _Land) tile then Nothing else Just (tile ^. tile_terrain)
           }
 
 --------------------------------------------------------------------------------

--- a/test/Test/LevelSpec.hs
+++ b/test/Test/LevelSpec.hs
@@ -52,12 +52,13 @@ genTilePlacement :: Gen TilePlacement
 genTilePlacement = do
   q <- choose (-50, 50)
   r <- choose (-50, 50)
-  -- at least one of content/background must be present
+  -- at least one of content/background/terrain must be present
   hasContent <- arbitrary
   hasBg      <- if hasContent then arbitrary else pure True
   content    <- if hasContent then Just <$> genTileContentDef else pure Nothing
   bg         <- if hasBg then Just <$> genBackground else pure Nothing
-  pure $ MkTilePlacement q r content bg
+  terrain    <- frequency [(1, Just <$> elements [Land, Water, Mountains]), (3, pure Nothing)]
+  pure $ MkTilePlacement q r content bg terrain
 
 genLevel :: Gen Level
 genLevel = do


### PR DESCRIPTION
## Summary
- Extend `TilePlacement` with an optional `terrain` field (`grass` / `water` / `mountains`), defaulting to `Land` when omitted
- Wire terrain encode/decode through TOML format with `terrainFromText`/`terrainToText` helpers
- Apply terrain in `applyPlacement` and capture non-Land terrain in `tileToPlacement` for full gamestate roundtripping
- Add water and mountain demo tiles to `level1.toml`
- Update property test generator to include terrain; existing roundtrip test covers it automatically

## Test plan
- [x] `cabal build` passes with no new warnings
- [x] All 97 tests pass including TOML roundtrip property tests
- [x] level1.toml roundtrip test covers the new terrain tiles
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)