### PR TITLE
Add context panel for selected tile info

### DIFF
--- a/game13.cabal
+++ b/game13.cabal
@@ -34,6 +34,7 @@ library
       Plunder.Mouse
       Plunder.Pathfinding
       Plunder.Render
+      Plunder.Render.ContextPanel
       Plunder.Render.Color
       Plunder.Render.Font
       Plunder.Render.Health

--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -85,14 +85,23 @@ mkGameState initGS helpOpen shopActions inventoryActions = do
   (alphaEvt, fireAlpha) <- newTriggerEvent
   (endTurnEvt, fireEndTurn) <- newTriggerEvent
 
+  winSizeDyn <- holdDyn (V2 640 480) $
+    fmap (fromIntegral <$>) (windowSizeChangedEventSize <$> windowSizeChangedEvt)
+
   let leftClickEvts :: Event t MouseButtonEventData
       leftClickEvts = ffilter (has (mouseButtons . leftClick)) mouseButtonEvt
       rightClickEvts :: Event t MouseButtonEventData
       rightClickEvts = ffilter (\x -> has (mouseButtons . rightClick) x
                                && has (mouseMotion . _Pressed) x
                                ) mouseButtonEvt
-      leftClickAxial = calcMouseClickAxial <$> leftClickEvts
-      rightClickAxialEvt = calcMouseClickAxial <$> rightClickEvts
+      onBoard :: V2 CInt -> MouseButtonEventData -> Maybe MouseButtonEventData
+      onBoard ws mbd = if isClickInPanel panelHeight ws mbd then Nothing else Just mbd
+      boardLeftClicks :: Event t MouseButtonEventData
+      boardLeftClicks  = attachWithMaybe onBoard (current winSizeDyn) leftClickEvts
+      boardRightClicks :: Event t MouseButtonEventData
+      boardRightClicks = attachWithMaybe onBoard (current winSizeDyn) rightClickEvts
+      leftClickAxial = calcMouseClickAxial <$> boardLeftClicks
+      rightClickAxialEvt = calcMouseClickAxial <$> boardRightClicks
       toggleInvEvt :: Event t ()
       toggleInvEvt = () <$ ffilter (\kd ->
           has _Pressed (keyboardEventKeyMotion kd) &&
@@ -137,9 +146,6 @@ mkGameState initGS helpOpen shopActions inventoryActions = do
         fireAlpha (fromIntegral (i * 11) `min` 220)
       threadDelay 4000000           -- hold for 4 s then reset
       fireReset ResetGame
-
-  winSizeDyn <- holdDyn (V2 640 480) $
-    fmap (fromIntegral <$>) (windowSizeChangedEventSize <$> windowSizeChangedEvt)
 
   performEvent_ $ ffor (describeState <$> updated state) $ liftIO . print
 

--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -20,13 +20,12 @@ import           System.Random
 import Plunder.Mouse
 import Plunder.Shop
 import Plunder.Render.Font(defaultFont, bigFont)
-import Plunder.Render.Shop
+import Plunder.Render.ContextPanel
 import Plunder.Render.Inventory
 import Plunder.Render.Banner
 import Plunder.Render.Help
 import Plunder.Render.Text (defaultStyle, surfaceToSettings, allocateText, textSurfaceSize)
 import Plunder.Render.Image (image)
-import Data.Maybe (isJust)
 import Control.Concurrent (forkIO, threadDelay)
 
 guest
@@ -52,10 +51,7 @@ guest initGS = mdo
 
   (gameState, alphaDyn, winSizeDyn, fireEndTurn) <- mkGameState initGS helpOpenDyn shopEvt inventoryClickEvt
   renderState font gameState
-  shopEvt <- renderShop font
-    (view game_shop <$> gameState)
-    (view (game_player_inventory . inventory_money) <$> gameState)
-    (isJust . findFreeAdjacent <$> gameState)
+  shopEvt <- renderContextPanel font gameState winSizeDyn
   inventoryClickEvt <- renderInventory font (view game_inventory_open <$> gameState) (view (game_player_inventory . inventroy_item) <$> gameState)
   renderBanner bannerFont (view game_phase <$> gameState) alphaDyn winSizeDyn
   okClickEvt <- renderHelp font helpOpenDyn winSizeDyn
@@ -63,7 +59,7 @@ guest initGS = mdo
   endTurnSurface <- allocateText font defaultStyle "[ End Turn ]"
   let V2 btnW btnH = textSurfaceSize endTurnSurface
       endTurnImgDyn = ffor winSizeDyn $ \(V2 w h) ->
-        Just $ surfaceToSettings endTurnSurface (P $ V2 (w - btnW - 10) (h - btnH - 10))
+        Just $ surfaceToSettings endTurnSurface (P $ V2 (w - btnW - 10) (h - panelHeight - btnH - 10))
   endTurnClicks <- image endTurnImgDyn
   performEvent_ $ ffor endTurnClicks $ \_ -> liftIO (fireEndTurn ())
   pure ()

--- a/src/Plunder/Mouse.hs
+++ b/src/Plunder/Mouse.hs
@@ -3,12 +3,22 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 
-module Plunder.Mouse where
+module Plunder.Mouse
+  ( leftClick
+  , rightClick
+  , mouseButtons
+  , mousePositions
+  , mouseMotion
+  , _Pressed
+  , calcMouseClickAxial
+  , isClickInPanel
+  ) where
 
 import           Control.Lens
 import           Data.Generics.Product
 import           Data.Generics.Sum
 import           Data.Int
+import           Foreign.C.Types (CInt)
 import           Plunder.Grid
 import           Reflex.SDL2
 
@@ -33,3 +43,10 @@ _Pressed = _Ctor @"Pressed"
 
 calcMouseClickAxial :: MouseButtonEventData -> Axial
 calcMouseClickAxial = pixelToAxial . fmap fromIntegral . view mousePositions
+
+-- | Returns 'True' when the click lands in the bottom panel area
+-- (Y coordinate >= windowHeight - panelH).
+isClickInPanel :: CInt -> V2 CInt -> MouseButtonEventData -> Bool
+isClickInPanel panelH (V2 _ winH) mbd =
+  let P (V2 _ y) = mbd ^. mousePositions
+  in fromIntegral y >= winH - panelH

--- a/src/Plunder/Render/ContextPanel.hs
+++ b/src/Plunder/Render/ContextPanel.hs
@@ -74,6 +74,16 @@ panelPos :: V2 CInt -> CInt -> CInt -> Point V2 CInt
 panelPos (V2 _ h) xOff lineIdx =
   P $ V2 (10 + xOff) (h - panelHeight + 10 + lineIdx * 18)
 
+-- | Display a single text element on screen by rendering and committing it.
+panelText
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Style -> Point V2 CInt -> Text -> m ()
+panelText font style pos txt = do
+  imgSettings <- renderText font style pos txt
+  void $ image (constDyn (Just imgSettings))
+
 renderPanelContent
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
@@ -81,19 +91,19 @@ renderPanelContent
   => Font -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ContextInfo -> m (Event t ShopAction)
 renderPanelContent _ _ _ _ ContextNone = pure never
 renderPanelContent font winSizeDyn _ _ (ContextEmpty terrain) = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderEmptyPanel font terrain <$> winSizeDyn)
+  void $ dynView $ renderEmptyPanel font terrain <$> winSizeDyn
   pure never
 renderPanelContent font winSizeDyn _ _ (ContextFog terrain) = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderFogPanel font terrain <$> winSizeDyn)
+  void $ dynView $ renderFogPanel font terrain <$> winSizeDyn
   pure never
 renderPanelContent font winSizeDyn _ _ (ContextPlayer terrain unit' inv) = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderPlayerPanel font terrain unit' inv <$> winSizeDyn)
+  void $ dynView $ renderPlayerPanel font terrain unit' inv <$> winSizeDyn
   pure never
 renderPanelContent font winSizeDyn _ _ (ContextEnemy terrain unit') = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderEnemyPanel font terrain unit' <$> winSizeDyn)
+  void $ dynView $ renderEnemyPanel font terrain unit' <$> winSizeDyn
   pure never
 renderPanelContent font winSizeDyn _ _ (ContextHouse terrain unit') = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderHousePanel font terrain unit' <$> winSizeDyn)
+  void $ dynView $ renderHousePanel font terrain unit' <$> winSizeDyn
   pure never
 renderPanelContent font winSizeDyn moneyDyn hasRoomDyn (ContextShop terrain content) =
   renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content
@@ -107,72 +117,71 @@ terrainLabel Land      = "Land"
 terrainLabel Water     = "Water"
 terrainLabel Mountains = "Mountains"
 
--- | Render terrain info in the right column of the panel.
-renderTerrainInfo
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> V2 CInt -> Terrain -> m ()
-renderTerrainInfo font winSize terrain =
-  void $ renderText font panelStyle (panelPos winSize 300 0)
-    ("Terrain: " <> terrainLabel terrain)
-
 renderEmptyPanel
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Terrain -> V2 CInt -> m (Maybe ImageSettings)
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Terrain -> V2 CInt -> m ()
 renderEmptyPanel font terrain winSize = do
-  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
-  Just <$> renderText font panelStyle (panelPos winSize 0 1) "Empty"
+  panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
+  panelText font panelStyle (panelPos winSize 0 1) "Empty"
 
 renderFogPanel
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Terrain -> V2 CInt -> m (Maybe ImageSettings)
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Terrain -> V2 CInt -> m ()
 renderFogPanel font terrain winSize = do
-  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Fog of war"
-  Just <$> renderText font panelStyle (panelPos winSize 0 1) ("Terrain: " <> terrainLabel terrain)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) "Fog of war"
+  panelText font panelStyle (panelPos winSize 0 1) ("Terrain: " <> terrainLabel terrain)
 
 renderPlayerPanel
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Terrain -> Unit -> PlayerInventory -> V2 CInt -> m (Maybe ImageSettings)
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Terrain -> Unit -> PlayerInventory -> V2 CInt -> m ()
 renderPlayerPanel font terrain unit' inv winSize = do
-  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Player"
-  void $ renderText font panelStyle (panelPos winSize 0 1)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) "Player"
+  panelText font panelStyle (panelPos winSize 0 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
-  void $ renderText font panelStyle (panelPos winSize 0 2)
+  panelText font panelStyle (panelPos winSize 0 2)
     ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
-  void $ renderText font panelStyle (panelPos winSize 0 3)
+  panelText font panelStyle (panelPos winSize 0 3)
     (describeStatus (unit' ^. unit_status))
-  void $ renderText font panelStyle (panelPos winSize 200 0)
+  panelText font panelStyle (panelPos winSize 200 0)
     ("Gold: " <> tshow (inv ^. inventory_money))
-  void $ renderText font panelStyle (panelPos winSize 200 1)
+  panelText font panelStyle (panelPos winSize 200 1)
     ("Items: " <> tshow (length (inv ^. inventroy_item)))
-  renderTerrainInfo font winSize terrain
-  Just <$> renderText font panelStyle (panelPos winSize 300 1)
-    " "
+  panelText font panelStyle (panelPos winSize 300 0)
+    ("Terrain: " <> terrainLabel terrain)
 
 renderEnemyPanel
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Terrain -> Unit -> V2 CInt -> m (Maybe ImageSettings)
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Terrain -> Unit -> V2 CInt -> m ()
 renderEnemyPanel font terrain unit' winSize = do
-  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Enemy"
-  void $ renderText font panelStyle (panelPos winSize 0 1)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) "Enemy"
+  panelText font panelStyle (panelPos winSize 0 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
-  void $ renderText font panelStyle (panelPos winSize 0 2)
+  panelText font panelStyle (panelPos winSize 0 2)
     ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
-  void $ renderText font panelStyle (panelPos winSize 0 3)
+  panelText font panelStyle (panelPos winSize 0 3)
     (describeStatus (unit' ^. unit_status))
-  renderTerrainInfo font winSize terrain
-  Just <$> renderText font panelStyle (panelPos winSize 300 1)
-    " "
+  panelText font panelStyle (panelPos winSize 300 0)
+    ("Terrain: " <> terrainLabel terrain)
 
 renderHousePanel
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Terrain -> Unit -> V2 CInt -> m (Maybe ImageSettings)
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Terrain -> Unit -> V2 CInt -> m ()
 renderHousePanel font terrain unit' winSize = do
-  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "House"
-  void $ renderText font panelStyle (panelPos winSize 0 1)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) "House"
+  panelText font panelStyle (panelPos winSize 0 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
-  renderTerrainInfo font winSize terrain
-  Just <$> renderText font panelStyle (panelPos winSize 300 1)
-    " "
+  panelText font panelStyle (panelPos winSize 300 0)
+    ("Terrain: " <> terrainLabel terrain)
 
 describeStatus :: Maybe StatusEffect -> Text
 describeStatus Nothing = "Status: none"
@@ -227,10 +236,10 @@ renderShopPanel
   => Font -> Terrain -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ShopContent -> m (Event t ShopAction)
 renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content = mdo
   -- Header and terrain
-  void $ image =<< holdDyn Nothing =<< dynView ((\ws -> do
-    void $ renderText font panelHeaderStyle (panelPos ws 0 0) "Shop"
-    renderTerrainInfo font ws terrain
-    Just <$> renderText font panelStyle (panelPos ws 300 1) " ") <$> winSizeDyn)
+  void $ dynView $ (\ws -> do
+    panelText font panelHeaderStyle (panelPos ws 0 0) "Shop"
+    panelText font panelStyle (panelPos ws 300 0) ("Terrain: " <> terrainLabel terrain)
+    ) <$> winSizeDyn
 
   -- Shop slots
   let slots :: [(Word8, ShopContent -> Maybe ShopItem)]

--- a/src/Plunder/Render/ContextPanel.hs
+++ b/src/Plunder/Render/ContextPanel.hs
@@ -105,6 +105,9 @@ renderPanelContent font winSizeDyn _ _ (ContextEnemy terrain unit') = do
 renderPanelContent font winSizeDyn _ _ (ContextHouse terrain unit') = do
   void $ dynView $ renderHousePanel font terrain unit' <$> winSizeDyn
   pure never
+renderPanelContent font winSizeDyn _ _ (ContextShopFar terrain) = do
+  void $ dynView $ renderShopFarPanel font terrain <$> winSizeDyn
+  pure never
 renderPanelContent font winSizeDyn moneyDyn hasRoomDyn (ContextShop terrain content) =
   renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content
 
@@ -183,6 +186,16 @@ renderHousePanel font terrain unit' winSize = do
   panelText font panelHeaderStyle (panelPos winSize contentXOff 0) "House"
   panelText font panelStyle (panelPos winSize contentXOff 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
+
+renderShopFarPanel
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Terrain -> V2 CInt -> m ()
+renderShopFarPanel font terrain winSize = do
+  panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
+  panelText font panelHeaderStyle (panelPos winSize contentXOff 0) "Shop"
+  panelText font panelStyle (panelPos winSize contentXOff 1) "Too far to shop"
 
 describeStatus :: Maybe StatusEffect -> Text
 describeStatus Nothing = "Status: none"

--- a/src/Plunder/Render/ContextPanel.hs
+++ b/src/Plunder/Render/ContextPanel.hs
@@ -117,6 +117,10 @@ terrainLabel Land      = "Land"
 terrainLabel Water     = "Water"
 terrainLabel Mountains = "Mountains"
 
+-- | X offset where content-specific info begins (right of terrain column).
+contentXOff :: CInt
+contentXOff = 120
+
 renderEmptyPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
@@ -124,7 +128,7 @@ renderEmptyPanel
   => Font -> Terrain -> V2 CInt -> m ()
 renderEmptyPanel font terrain winSize = do
   panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
-  panelText font panelStyle (panelPos winSize 0 1) "Empty"
+  panelText font panelStyle (panelPos winSize contentXOff 0) "Empty"
 
 renderFogPanel
   :: ReflexSDL2 t m
@@ -132,8 +136,8 @@ renderFogPanel
   => MonadReader Renderer m
   => Font -> Terrain -> V2 CInt -> m ()
 renderFogPanel font terrain winSize = do
-  panelText font panelHeaderStyle (panelPos winSize 0 0) "Fog of war"
-  panelText font panelStyle (panelPos winSize 0 1) ("Terrain: " <> terrainLabel terrain)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
+  panelText font panelStyle (panelPos winSize contentXOff 0) "Fog of war"
 
 renderPlayerPanel
   :: ReflexSDL2 t m
@@ -141,19 +145,18 @@ renderPlayerPanel
   => MonadReader Renderer m
   => Font -> Terrain -> Unit -> PlayerInventory -> V2 CInt -> m ()
 renderPlayerPanel font terrain unit' inv winSize = do
-  panelText font panelHeaderStyle (panelPos winSize 0 0) "Player"
-  panelText font panelStyle (panelPos winSize 0 1)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
+  panelText font panelHeaderStyle (panelPos winSize contentXOff 0) "Player"
+  panelText font panelStyle (panelPos winSize contentXOff 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
-  panelText font panelStyle (panelPos winSize 0 2)
+  panelText font panelStyle (panelPos winSize contentXOff 2)
     ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
-  panelText font panelStyle (panelPos winSize 0 3)
+  panelText font panelStyle (panelPos winSize contentXOff 3)
     (describeStatus (unit' ^. unit_status))
-  panelText font panelStyle (panelPos winSize 200 0)
+  panelText font panelStyle (panelPos winSize 320 0)
     ("Gold: " <> tshow (inv ^. inventory_money))
-  panelText font panelStyle (panelPos winSize 200 1)
+  panelText font panelStyle (panelPos winSize 320 1)
     ("Items: " <> tshow (length (inv ^. inventroy_item)))
-  panelText font panelStyle (panelPos winSize 300 0)
-    ("Terrain: " <> terrainLabel terrain)
 
 renderEnemyPanel
   :: ReflexSDL2 t m
@@ -161,15 +164,14 @@ renderEnemyPanel
   => MonadReader Renderer m
   => Font -> Terrain -> Unit -> V2 CInt -> m ()
 renderEnemyPanel font terrain unit' winSize = do
-  panelText font panelHeaderStyle (panelPos winSize 0 0) "Enemy"
-  panelText font panelStyle (panelPos winSize 0 1)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
+  panelText font panelHeaderStyle (panelPos winSize contentXOff 0) "Enemy"
+  panelText font panelStyle (panelPos winSize contentXOff 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
-  panelText font panelStyle (panelPos winSize 0 2)
+  panelText font panelStyle (panelPos winSize contentXOff 2)
     ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
-  panelText font panelStyle (panelPos winSize 0 3)
+  panelText font panelStyle (panelPos winSize contentXOff 3)
     (describeStatus (unit' ^. unit_status))
-  panelText font panelStyle (panelPos winSize 300 0)
-    ("Terrain: " <> terrainLabel terrain)
 
 renderHousePanel
   :: ReflexSDL2 t m
@@ -177,11 +179,10 @@ renderHousePanel
   => MonadReader Renderer m
   => Font -> Terrain -> Unit -> V2 CInt -> m ()
 renderHousePanel font terrain unit' winSize = do
-  panelText font panelHeaderStyle (panelPos winSize 0 0) "House"
-  panelText font panelStyle (panelPos winSize 0 1)
+  panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
+  panelText font panelHeaderStyle (panelPos winSize contentXOff 0) "House"
+  panelText font panelStyle (panelPos winSize contentXOff 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
-  panelText font panelStyle (panelPos winSize 300 0)
-    ("Terrain: " <> terrainLabel terrain)
 
 describeStatus :: Maybe StatusEffect -> Text
 describeStatus Nothing = "Status: none"
@@ -235,13 +236,13 @@ renderShopPanel
   => MonadReader Renderer m
   => Font -> Terrain -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ShopContent -> m (Event t ShopAction)
 renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content = mdo
-  -- Header and terrain
+  -- Terrain (left) and header (right)
   void $ dynView $ (\ws -> do
-    panelText font panelHeaderStyle (panelPos ws 0 0) "Shop"
-    panelText font panelStyle (panelPos ws 300 0) ("Terrain: " <> terrainLabel terrain)
+    panelText font panelHeaderStyle (panelPos ws 0 0) (terrainLabel terrain)
+    panelText font panelHeaderStyle (panelPos ws contentXOff 0) "Shop"
     ) <$> winSizeDyn
 
-  -- Shop slots
+  -- Shop slots (right of terrain)
   let slots :: [(Word8, ShopContent -> Maybe ShopItem)]
       slots = [(0, slot1), (1, slot2), (2, slot3)]
 
@@ -253,7 +254,7 @@ renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content = mdo
 
   -- Purchase button
   purchaseSurface <- allocateText font panelStyle "Purchase"
-  let purchasePosDyn = (\ws -> surfaceToSettings purchaseSurface (panelPos ws 200 0)) <$> winSizeDyn
+  let purchasePosDyn = (\ws -> surfaceToSettings purchaseSurface (panelPos ws 320 0)) <$> winSizeDyn
   purchaseClick <- image (Just <$> purchasePosDyn)
 
   let purchaseResult = (\money hasRoom sel -> purchaseAction money hasRoom sel content)
@@ -270,7 +271,7 @@ renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content = mdo
 
   -- Exit button
   exitSurface <- allocateText font panelStyle "Exit"
-  let exitPosDyn = (\ws -> surfaceToSettings exitSurface (panelPos ws 200 2)) <$> winSizeDyn
+  let exitPosDyn = (\ws -> surfaceToSettings exitSurface (panelPos ws 320 2)) <$> winSizeDyn
   exitClick <- image (Just <$> exitPosDyn)
 
   pure $ leftmost [MkBought <$> purchaseSuccess, MkExited <$ exitClick]
@@ -288,8 +289,8 @@ renderShopSlot font content idx slotAccessor winSize sel = do
   let style = if Map.member idx (selectedSlots sel) then shopSelectedStyle else panelStyle
       lineIdx = fromIntegral idx + 1
   case slotAccessor content of
-    Nothing   -> Just <$> renderText font panelStyle (panelPos winSize 0 lineIdx) "-"
-    Just item -> Just <$> renderText font style (panelPos winSize 0 lineIdx) (itemDescription item)
+    Nothing   -> Just <$> renderText font panelStyle (panelPos winSize contentXOff lineIdx) "-"
+    Just item -> Just <$> renderText font style (panelPos winSize contentXOff lineIdx) (itemDescription item)
 
 isJust :: Maybe a -> Bool
 isJust (Just _) = True

--- a/src/Plunder/Render/ContextPanel.hs
+++ b/src/Plunder/Render/ContextPanel.hs
@@ -1,0 +1,250 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecursiveDo         #-}
+
+module Plunder.Render.ContextPanel(
+  renderContextPanel
+  , panelHeight
+  ) where
+
+import           Control.Lens
+import           Control.Monad
+import           Control.Monad.Reader (MonadReader (..))
+import           Data.Text (Text)
+import qualified Data.Map as Map
+import           Data.Map (Map)
+import           Data.Set (Set)
+import           Data.Set.Lens
+import           Data.Word (Word8, Word64)
+import           Foreign.C.Types (CInt)
+import           Plunder.Combat
+import           Plunder.Render.Color
+import           Plunder.Render.Font
+import           Plunder.Render.Image
+import           Plunder.Render.Layer
+import           Plunder.Render.Text
+import           Plunder.Shop
+import           Plunder.State
+import           Reflex
+import           Reflex.SDL2
+
+-- | Fixed height of the context panel at the bottom of the screen.
+panelHeight :: CInt
+panelHeight = 120
+
+-- | Style used for context panel labels.
+panelStyle :: Style
+panelStyle = defaultStyle & styleColorLens .~ V4 220 220 220 255
+
+panelHeaderStyle :: Style
+panelHeaderStyle = defaultStyle & styleColorLens .~ V4 255 255 255 255
+
+shopSelectedStyle :: Style
+shopSelectedStyle = panelStyle & styleColorLens .~ V4 200 30 30 255
+
+-- | Render a context panel at the bottom of the screen showing info about the
+--   selected tile.  Returns shop purchase events when a shop is selected.
+renderContextPanel
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Dynamic t GameState -> Dynamic t (V2 CInt) -> m (Event t ShopAction)
+renderContextPanel font gameState winSizeDyn = do
+  let contextDyn = selectedTileInfo <$> gameState
+      moneyDyn   = view (game_player_inventory . inventory_money) <$> gameState
+      hasRoomDyn = isJust . findFreeAdjacent <$> gameState
+
+  renderer <- ask
+
+  -- Draw dark panel background
+  commitLayer $ ffor2 contextDyn winSizeDyn $ \ctx (V2 w h) ->
+    case ctx of
+      ContextEmpty _ -> pure ()
+      _              -> do
+        setDrawColor renderer (V4 30 30 30 220)
+        fillRect renderer (Just (Rectangle (P $ V2 0 (h - panelHeight)) (V2 w panelHeight)))
+
+  -- Render content using dynView; switchHold flattens the shop events
+  shopEvtEvt <- dynView $ renderPanelContent font winSizeDyn moneyDyn hasRoomDyn <$> contextDyn
+  switchHold never shopEvtEvt
+
+-- | Position helper: compute a point in the panel given window size and offsets
+panelPos :: V2 CInt -> CInt -> CInt -> Point V2 CInt
+panelPos (V2 _ h) xOff lineIdx =
+  P $ V2 (10 + xOff) (h - panelHeight + 10 + lineIdx * 18)
+
+renderPanelContent
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ContextInfo -> m (Event t ShopAction)
+renderPanelContent _ _ _ _ (ContextEmpty _) = pure never
+renderPanelContent font winSizeDyn _ _ ContextFog = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderFogPanel font <$> winSizeDyn)
+  pure never
+renderPanelContent font winSizeDyn _ _ (ContextPlayer unit' inv) = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderPlayerPanel font unit' inv <$> winSizeDyn)
+  pure never
+renderPanelContent font winSizeDyn _ _ (ContextEnemy unit') = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderEnemyPanel font unit' <$> winSizeDyn)
+  pure never
+renderPanelContent font winSizeDyn _ _ (ContextHouse unit') = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderHousePanel font unit' <$> winSizeDyn)
+  pure never
+renderPanelContent font winSizeDyn moneyDyn hasRoomDyn (ContextShop content) =
+  renderShopPanel font winSizeDyn moneyDyn hasRoomDyn content
+
+--------------------------------------------------------------------------------
+-- Individual panel renderers
+--------------------------------------------------------------------------------
+
+renderFogPanel
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> V2 CInt -> m (Maybe ImageSettings)
+renderFogPanel font winSize =
+  Just <$> renderText font panelHeaderStyle (panelPos winSize 0 0) "Fog of war"
+
+renderPlayerPanel
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> Unit -> PlayerInventory -> V2 CInt -> m (Maybe ImageSettings)
+renderPlayerPanel font unit' inv winSize = do
+  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Player"
+  void $ renderText font panelStyle (panelPos winSize 0 1)
+    ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
+  void $ renderText font panelStyle (panelPos winSize 0 2)
+    ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
+  void $ renderText font panelStyle (panelPos winSize 0 3)
+    (describeStatus (unit' ^. unit_status))
+  void $ renderText font panelStyle (panelPos winSize 150 0)
+    ("Gold: " <> tshow (inv ^. inventory_money))
+  Just <$> renderText font panelStyle (panelPos winSize 150 1)
+    ("Items: " <> tshow (length (inv ^. inventroy_item)))
+
+renderEnemyPanel
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> Unit -> V2 CInt -> m (Maybe ImageSettings)
+renderEnemyPanel font unit' winSize = do
+  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Enemy"
+  void $ renderText font panelStyle (panelPos winSize 0 1)
+    ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
+  void $ renderText font panelStyle (panelPos winSize 0 2)
+    ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
+  Just <$> renderText font panelStyle (panelPos winSize 0 3)
+    (describeStatus (unit' ^. unit_status))
+
+renderHousePanel
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> Unit -> V2 CInt -> m (Maybe ImageSettings)
+renderHousePanel font unit' winSize = do
+  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "House"
+  Just <$> renderText font panelStyle (panelPos winSize 0 1)
+    ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
+
+describeStatus :: Maybe StatusEffect -> Text
+describeStatus Nothing = "Status: none"
+describeStatus (Just DrinkingPotion) = "Status: drinking"
+describeStatus (Just (Healing n)) = "Status: healing (" <> tshow n <> ")"
+
+--------------------------------------------------------------------------------
+-- Shop panel (interactive)
+--------------------------------------------------------------------------------
+
+newtype ShopSelection = MkShopSelection
+  { selectedSlots :: Map Word8 (ShopContent -> Maybe ShopItem) }
+
+initialSelection :: ShopSelection
+initialSelection = MkShopSelection mempty
+
+toggleSlot :: ShopSelection -> (Word8, ShopContent -> Maybe ShopItem) -> ShopSelection
+toggleSlot (MkShopSelection m) (idx, slot) = MkShopSelection $
+  if Map.member idx m then Map.delete idx m
+  else Map.insert idx slot m
+
+data PurchaseError = ShopClosed
+                   | NotEnoughMoney
+                   | NoItemsSelected
+                   | NoRoomForFriend
+
+renderPurchaseError :: PurchaseError -> Text
+renderPurchaseError = \case
+  ShopClosed      -> "Shop closed"
+  NotEnoughMoney  -> "Insufficient money"
+  NoItemsSelected -> "Nothing selected"
+  NoRoomForFriend -> "No room for friend"
+
+purchaseAction :: Word64 -> Bool -> ShopSelection -> ShopContent -> Either PurchaseError Haul
+purchaseAction playerMoney hasRoom sel content =
+  let counter :: Set ShopItem
+      counter = setOf (traversed . to (\fun -> fun content) . traversed) $ selectedSlots sel
+      price = sumOf (folded . si_priceLens) counter
+      wantsFriend = any (\i -> si_type i == ShopUnit) counter
+  in if | length counter < 1          -> Left NoItemsSelected
+        | playerMoney < price         -> Left NotEnoughMoney
+        | wantsFriend && not hasRoom  -> Left NoRoomForFriend
+        | True -> Right $ MkHaul
+            { haulItems = counter
+            , haulNewMoney = playerMoney - price
+            }
+
+renderShopPanel
+  :: ReflexSDL2 t m
+  => DynamicWriter t [Layer m] m
+  => MonadReader Renderer m
+  => Font -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ShopContent -> m (Event t ShopAction)
+renderShopPanel font winSizeDyn moneyDyn hasRoomDyn content = mdo
+  -- Header
+  void $ image =<< holdDyn Nothing =<< dynView ((\ws -> Just <$> renderText font panelHeaderStyle (panelPos ws 0 0) "Shop") <$> winSizeDyn)
+
+  -- Shop slots
+  let slots :: [(Word8, ShopContent -> Maybe ShopItem)]
+      slots = [(0, slot1), (1, slot2), (2, slot3)]
+
+  slotEvts <- forM slots $ \(idx, slotAccessor) ->
+    fmap ((idx, slotAccessor) <$) $
+      image =<< holdDyn Nothing =<< dynView (renderShopSlot font content idx slotAccessor <$> winSizeDyn <*> selDyn)
+
+  selDyn <- accumDyn toggleSlot initialSelection $ leftmost slotEvts
+
+  -- Purchase button
+  purchaseSurface <- allocateText font panelStyle "Purchase"
+  let purchasePosDyn = (\ws -> surfaceToSettings purchaseSurface (panelPos ws 200 0)) <$> winSizeDyn
+  purchaseClick <- image (Just <$> purchasePosDyn)
+
+  let purchaseResult = (\money hasRoom sel -> purchaseAction money hasRoom sel content)
+        <$> current moneyDyn <*> current hasRoomDyn <*> current selDyn
+      (purchaseError, purchaseSuccess) = fanEither $ purchaseResult <@ purchaseClick
+
+  -- Error display
+  small <- smallFont
+  void $ image =<< holdView (pure Nothing)
+    (sequence . renderErrorText small <$> leftmost
+      [ Just <$> purchaseError
+      , Nothing <$ updated selDyn  -- clear error when selection changes
+      ])
+
+  -- Exit button
+  exitSurface <- allocateText font panelStyle "Exit"
+  let exitPosDyn = (\ws -> surfaceToSettings exitSurface (panelPos ws 200 2)) <$> winSizeDyn
+  exitClick <- image (Just <$> exitPosDyn)
+
+  pure $ leftmost [MkBought <$> purchaseSuccess, MkExited <$ exitClick]
+
+renderErrorText
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> Maybe PurchaseError -> Maybe (m ImageSettings)
+renderErrorText _ Nothing = Nothing
+renderErrorText small (Just err) = Just $ renderText small panelStyle (P $ V2 300 10) (renderPurchaseError err)
+
+renderShopSlot
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> ShopContent -> Word8 -> (ShopContent -> Maybe ShopItem) -> V2 CInt -> ShopSelection -> m (Maybe ImageSettings)
+renderShopSlot font content idx slotAccessor winSize sel = do
+  let style = if Map.member idx (selectedSlots sel) then shopSelectedStyle else panelStyle
+      lineIdx = fromIntegral idx + 1
+  case slotAccessor content of
+    Nothing   -> Just <$> renderText font panelStyle (panelPos winSize 0 lineIdx) "-"
+    Just item -> Just <$> renderText font style (panelPos winSize 0 lineIdx) (itemDescription item)
+
+isJust :: Maybe a -> Bool
+isJust (Just _) = True
+isJust Nothing  = False

--- a/src/Plunder/Render/ContextPanel.hs
+++ b/src/Plunder/Render/ContextPanel.hs
@@ -18,6 +18,7 @@ import           Data.Set.Lens
 import           Data.Word (Word8, Word64)
 import           Foreign.C.Types (CInt)
 import           Plunder.Combat
+import           Plunder.Grid (Terrain(..))
 import           Plunder.Render.Color
 import           Plunder.Render.Font
 import           Plunder.Render.Image
@@ -59,8 +60,8 @@ renderContextPanel font gameState winSizeDyn = do
   -- Draw dark panel background
   commitLayer $ ffor2 contextDyn winSizeDyn $ \ctx (V2 w h) ->
     case ctx of
-      ContextEmpty _ -> pure ()
-      _              -> do
+      ContextNone -> pure ()
+      _           -> do
         setDrawColor renderer (V4 30 30 30 220)
         fillRect renderer (Just (Rectangle (P $ V2 0 (h - panelHeight)) (V2 w panelHeight)))
 
@@ -78,36 +79,60 @@ renderPanelContent
   => DynamicWriter t [Layer m] m
   => MonadReader Renderer m
   => Font -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ContextInfo -> m (Event t ShopAction)
-renderPanelContent _ _ _ _ (ContextEmpty _) = pure never
-renderPanelContent font winSizeDyn _ _ ContextFog = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderFogPanel font <$> winSizeDyn)
+renderPanelContent _ _ _ _ ContextNone = pure never
+renderPanelContent font winSizeDyn _ _ (ContextEmpty terrain) = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderEmptyPanel font terrain <$> winSizeDyn)
   pure never
-renderPanelContent font winSizeDyn _ _ (ContextPlayer unit' inv) = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderPlayerPanel font unit' inv <$> winSizeDyn)
+renderPanelContent font winSizeDyn _ _ (ContextFog terrain) = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderFogPanel font terrain <$> winSizeDyn)
   pure never
-renderPanelContent font winSizeDyn _ _ (ContextEnemy unit') = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderEnemyPanel font unit' <$> winSizeDyn)
+renderPanelContent font winSizeDyn _ _ (ContextPlayer terrain unit' inv) = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderPlayerPanel font terrain unit' inv <$> winSizeDyn)
   pure never
-renderPanelContent font winSizeDyn _ _ (ContextHouse unit') = do
-  void $ image =<< holdDyn Nothing =<< dynView (renderHousePanel font unit' <$> winSizeDyn)
+renderPanelContent font winSizeDyn _ _ (ContextEnemy terrain unit') = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderEnemyPanel font terrain unit' <$> winSizeDyn)
   pure never
-renderPanelContent font winSizeDyn moneyDyn hasRoomDyn (ContextShop content) =
-  renderShopPanel font winSizeDyn moneyDyn hasRoomDyn content
+renderPanelContent font winSizeDyn _ _ (ContextHouse terrain unit') = do
+  void $ image =<< holdDyn Nothing =<< dynView (renderHousePanel font terrain unit' <$> winSizeDyn)
+  pure never
+renderPanelContent font winSizeDyn moneyDyn hasRoomDyn (ContextShop terrain content) =
+  renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content
 
 --------------------------------------------------------------------------------
 -- Individual panel renderers
 --------------------------------------------------------------------------------
 
+terrainLabel :: Terrain -> Text
+terrainLabel Land      = "Land"
+terrainLabel Water     = "Water"
+terrainLabel Mountains = "Mountains"
+
+-- | Render terrain info in the right column of the panel.
+renderTerrainInfo
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> V2 CInt -> Terrain -> m ()
+renderTerrainInfo font winSize terrain =
+  void $ renderText font panelStyle (panelPos winSize 300 0)
+    ("Terrain: " <> terrainLabel terrain)
+
+renderEmptyPanel
+  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  => Font -> Terrain -> V2 CInt -> m (Maybe ImageSettings)
+renderEmptyPanel font terrain winSize = do
+  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
+  Just <$> renderText font panelStyle (panelPos winSize 0 1) "Empty"
+
 renderFogPanel
   :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> V2 CInt -> m (Maybe ImageSettings)
-renderFogPanel font winSize =
-  Just <$> renderText font panelHeaderStyle (panelPos winSize 0 0) "Fog of war"
+  => Font -> Terrain -> V2 CInt -> m (Maybe ImageSettings)
+renderFogPanel font terrain winSize = do
+  void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Fog of war"
+  Just <$> renderText font panelStyle (panelPos winSize 0 1) ("Terrain: " <> terrainLabel terrain)
 
 renderPlayerPanel
   :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Unit -> PlayerInventory -> V2 CInt -> m (Maybe ImageSettings)
-renderPlayerPanel font unit' inv winSize = do
+  => Font -> Terrain -> Unit -> PlayerInventory -> V2 CInt -> m (Maybe ImageSettings)
+renderPlayerPanel font terrain unit' inv winSize = do
   void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Player"
   void $ renderText font panelStyle (panelPos winSize 0 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
@@ -115,30 +140,39 @@ renderPlayerPanel font unit' inv winSize = do
     ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
   void $ renderText font panelStyle (panelPos winSize 0 3)
     (describeStatus (unit' ^. unit_status))
-  void $ renderText font panelStyle (panelPos winSize 150 0)
+  void $ renderText font panelStyle (panelPos winSize 200 0)
     ("Gold: " <> tshow (inv ^. inventory_money))
-  Just <$> renderText font panelStyle (panelPos winSize 150 1)
+  void $ renderText font panelStyle (panelPos winSize 200 1)
     ("Items: " <> tshow (length (inv ^. inventroy_item)))
+  renderTerrainInfo font winSize terrain
+  Just <$> renderText font panelStyle (panelPos winSize 300 1)
+    " "
 
 renderEnemyPanel
   :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Unit -> V2 CInt -> m (Maybe ImageSettings)
-renderEnemyPanel font unit' winSize = do
+  => Font -> Terrain -> Unit -> V2 CInt -> m (Maybe ImageSettings)
+renderEnemyPanel font terrain unit' winSize = do
   void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "Enemy"
   void $ renderText font panelStyle (panelPos winSize 0 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
   void $ renderText font panelStyle (panelPos winSize 0 2)
     ("Weapon: " <> maybe "none" weaponDescription (unit' ^. unit_weapon))
-  Just <$> renderText font panelStyle (panelPos winSize 0 3)
+  void $ renderText font panelStyle (panelPos winSize 0 3)
     (describeStatus (unit' ^. unit_status))
+  renderTerrainInfo font winSize terrain
+  Just <$> renderText font panelStyle (panelPos winSize 300 1)
+    " "
 
 renderHousePanel
   :: (ReflexSDL2 t m, MonadReader Renderer m)
-  => Font -> Unit -> V2 CInt -> m (Maybe ImageSettings)
-renderHousePanel font unit' winSize = do
+  => Font -> Terrain -> Unit -> V2 CInt -> m (Maybe ImageSettings)
+renderHousePanel font terrain unit' winSize = do
   void $ renderText font panelHeaderStyle (panelPos winSize 0 0) "House"
-  Just <$> renderText font panelStyle (panelPos winSize 0 1)
+  void $ renderText font panelStyle (panelPos winSize 0 1)
     ("HP: " <> tshow (unit' ^. unit_hp) <> "/" <> tshow maxHealth)
+  renderTerrainInfo font winSize terrain
+  Just <$> renderText font panelStyle (panelPos winSize 300 1)
+    " "
 
 describeStatus :: Maybe StatusEffect -> Text
 describeStatus Nothing = "Status: none"
@@ -190,10 +224,13 @@ renderShopPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
   => MonadReader Renderer m
-  => Font -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ShopContent -> m (Event t ShopAction)
-renderShopPanel font winSizeDyn moneyDyn hasRoomDyn content = mdo
-  -- Header
-  void $ image =<< holdDyn Nothing =<< dynView ((\ws -> Just <$> renderText font panelHeaderStyle (panelPos ws 0 0) "Shop") <$> winSizeDyn)
+  => Font -> Terrain -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ShopContent -> m (Event t ShopAction)
+renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content = mdo
+  -- Header and terrain
+  void $ image =<< holdDyn Nothing =<< dynView ((\ws -> do
+    void $ renderText font panelHeaderStyle (panelPos ws 0 0) "Shop"
+    renderTerrainInfo font ws terrain
+    Just <$> renderText font panelStyle (panelPos ws 300 1) " ") <$> winSizeDyn)
 
   -- Shop slots
   let slots :: [(Word8, ShopContent -> Maybe ShopItem)]

--- a/src/Plunder/Render/Text.hs
+++ b/src/Plunder/Render/Text.hs
@@ -42,6 +42,8 @@ data TextSurface = MkTextSurface
   , textSurfaceStyle :: Style
   }
 
+-- | Create a 'TextSurface' from a font, style, and text string.
+--   This only allocates the SDL texture; it does not draw anything on screen.
 allocateText :: (ReflexSDL2 t m, MonadReader Renderer m) => Font -> Style -> Text -> m TextSurface
 allocateText font style text = do
       r    <- ask
@@ -57,6 +59,8 @@ allocateText font style text = do
       where
        color = styleColor style
 
+-- | Convert a 'TextSurface' and a screen position into 'ImageSettings'.
+--   Pure conversion — does not draw anything; pass the result to 'image' to display.
 surfaceToSettings :: TextSurface -> Point V2 CInt -> ImageSettings
 surfaceToSettings surface position  =
       ImageSettings
@@ -75,6 +79,13 @@ surfaceToSettings surface position  =
 textSurfaceSize :: TextSurface -> V2 CInt
 textSurfaceSize = textSurfaceFontHexSize
 
+-- | Allocate a text texture and return its 'ImageSettings'.
+--
+--   __This does NOT display anything on screen.__  To actually render the text,
+--   pass the returned 'ImageSettings' to 'image' (which calls 'commitLayer').
+--
+--   For a convenience wrapper that renders /and/ displays in one step, see
+--   @panelText@ in "Plunder.Render.ContextPanel".
 renderText :: ReflexSDL2 t m
   => MonadReader Renderer m
   => Font -> Style -> Point V2 CInt -> Text -> m ImageSettings

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -38,6 +38,7 @@ module Plunder.State(GameState(..)
             , tileVisibility
             , ContextInfo(..)
             , selectedTileInfo
+            , contextTerrain
             ) where
 
 import qualified Control.Monad.State.Class as SC
@@ -80,6 +81,16 @@ data ContextInfo
   | ContextEmpty Terrain
   | ContextNone
   deriving (Show, Eq)
+
+-- | Extract the terrain from a 'ContextInfo', if present.
+contextTerrain :: ContextInfo -> Maybe Terrain
+contextTerrain (ContextPlayer terrain _ _) = Just terrain
+contextTerrain (ContextEnemy terrain _)    = Just terrain
+contextTerrain (ContextHouse terrain _)    = Just terrain
+contextTerrain (ContextShop terrain _)     = Just terrain
+contextTerrain (ContextFog terrain)        = Just terrain
+contextTerrain (ContextEmpty terrain)      = Just terrain
+contextTerrain ContextNone                 = Nothing
 
 -- | inidicates the stuff in "pockets", so this doesn't mean equiped
 --   equiped is handled by tile content.
@@ -479,7 +490,9 @@ spawnFriend = do
 
 applyShopUpdates :: MonadState GameState m => ShopAction -> m ()
 applyShopUpdates = \case
-    MkExited -> assign game_shop Nothing
+    MkExited -> do
+      assign game_shop Nothing
+      assign game_selected Nothing
     MkBought bought -> do
       assign game_shop Nothing
       game_pending_purchase .= Just bought

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -77,6 +77,7 @@ data ContextInfo
   | ContextEnemy Terrain Unit
   | ContextHouse Terrain Unit
   | ContextShop Terrain ShopContent
+  | ContextShopFar Terrain        -- ^ shop visible but too far to interact
   | ContextFog Terrain
   | ContextEmpty Terrain
   | ContextNone
@@ -88,6 +89,7 @@ contextTerrain (ContextPlayer terrain _ _) = Just terrain
 contextTerrain (ContextEnemy terrain _)    = Just terrain
 contextTerrain (ContextHouse terrain _)    = Just terrain
 contextTerrain (ContextShop terrain _)     = Just terrain
+contextTerrain (ContextShopFar terrain)    = Just terrain
 contextTerrain (ContextFog terrain)        = Just terrain
 contextTerrain (ContextEmpty terrain)      = Just terrain
 contextTerrain ContextNone                 = Nothing
@@ -148,7 +150,7 @@ selectedTileInfo :: GameState -> ContextInfo
 selectedTileInfo gs = case gs ^. game_selected of
   Nothing    -> ContextNone
   Just axial -> case gs ^. game_board . at axial of
-    Nothing   -> ContextEmpty Land          -- off-grid
+    Nothing   -> ContextNone                -- off-grid
     Just tile ->
       let terrain = tile ^. tile_terrain
       in case tileVisibility gs axial of
@@ -159,7 +161,10 @@ selectedTileInfo gs = case gs ^. game_selected of
           Just (Player unit) -> ContextPlayer terrain unit (gs ^. game_player_inventory)
           Just (Enemy unit)  -> ContextEnemy terrain unit
           Just (House unit)  -> ContextHouse terrain unit
-          Just (Shop content) -> ContextShop terrain content
+          Just (Shop content)
+            | any (`elem` neigbours axial) (playerPositions gs)
+                             -> ContextShop terrain content
+            | otherwise      -> ContextShopFar terrain
 
 -- | Compute the set of tiles currently within sight range (distance < 5).
 computeNewlyExplored :: GameState -> Set Axial

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -72,12 +72,13 @@ data Visibility = Visible | Fog | Unexplored deriving (Show, Eq)
 
 -- | What the context panel shows for a selected tile.
 data ContextInfo
-  = ContextPlayer Unit PlayerInventory
-  | ContextEnemy Unit
-  | ContextHouse Unit
-  | ContextShop ShopContent
-  | ContextFog
+  = ContextPlayer Terrain Unit PlayerInventory
+  | ContextEnemy Terrain Unit
+  | ContextHouse Terrain Unit
+  | ContextShop Terrain ShopContent
+  | ContextFog Terrain
   | ContextEmpty Terrain
+  | ContextNone
   deriving (Show, Eq)
 
 -- | inidicates the stuff in "pockets", so this doesn't mean equiped
@@ -134,18 +135,20 @@ tileVisibility gs axial =
 -- | Derive context-panel info for the currently selected tile.
 selectedTileInfo :: GameState -> ContextInfo
 selectedTileInfo gs = case gs ^. game_selected of
-  Nothing    -> ContextEmpty Land
+  Nothing    -> ContextNone
   Just axial -> case gs ^. game_board . at axial of
     Nothing   -> ContextEmpty Land          -- off-grid
-    Just tile -> case tileVisibility gs axial of
-      Unexplored -> ContextEmpty (tile ^. tile_terrain)
-      Fog        -> ContextFog
-      Visible    -> case tile ^. tile_content of
-        Nothing            -> ContextEmpty (tile ^. tile_terrain)
-        Just (Player unit) -> ContextPlayer unit (gs ^. game_player_inventory)
-        Just (Enemy unit)  -> ContextEnemy unit
-        Just (House unit)  -> ContextHouse unit
-        Just (Shop content) -> ContextShop content
+    Just tile ->
+      let terrain = tile ^. tile_terrain
+      in case tileVisibility gs axial of
+        Unexplored -> ContextEmpty terrain
+        Fog        -> ContextFog terrain
+        Visible    -> case tile ^. tile_content of
+          Nothing            -> ContextEmpty terrain
+          Just (Player unit) -> ContextPlayer terrain unit (gs ^. game_player_inventory)
+          Just (Enemy unit)  -> ContextEnemy terrain unit
+          Just (House unit)  -> ContextHouse terrain unit
+          Just (Shop content) -> ContextShop terrain content
 
 -- | Compute the set of tiles currently within sight range (distance < 5).
 computeNewlyExplored :: GameState -> Set Axial

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -36,6 +36,8 @@ module Plunder.State(GameState(..)
             , findFreeAdjacent
             , playerPositions
             , tileVisibility
+            , ContextInfo(..)
+            , selectedTileInfo
             ) where
 
 import qualified Control.Monad.State.Class as SC
@@ -68,13 +70,23 @@ data GamePhase = Playing | YouDied | YouVictorious deriving (Show, Eq)
 
 data Visibility = Visible | Fog | Unexplored deriving (Show, Eq)
 
+-- | What the context panel shows for a selected tile.
+data ContextInfo
+  = ContextPlayer Unit PlayerInventory
+  | ContextEnemy Unit
+  | ContextHouse Unit
+  | ContextShop ShopContent
+  | ContextFog
+  | ContextEmpty Terrain
+  deriving (Show, Eq)
+
 -- | inidicates the stuff in "pockets", so this doesn't mean equiped
 --   equiped is handled by tile content.
 data PlayerInventory = MkInventory {
    -- | indicating how much money a player has
     _inventory_money :: Word64
   , _inventroy_item  :: Set ShopItem
-  } deriving (Show)
+  } deriving (Show, Eq)
 
 data GameState = MkGameState
   { _game_selected          :: Maybe Axial
@@ -118,6 +130,22 @@ tileVisibility gs axial =
          else if minDist <= 4 then Fog
          else if Set.member axial (gs ^. game_explored) then Fog
          else Unexplored
+
+-- | Derive context-panel info for the currently selected tile.
+selectedTileInfo :: GameState -> ContextInfo
+selectedTileInfo gs = case gs ^. game_selected of
+  Nothing    -> ContextEmpty Land
+  Just axial -> case gs ^. game_board . at axial of
+    Nothing   -> ContextEmpty Land          -- off-grid
+    Just tile -> case tileVisibility gs axial of
+      Unexplored -> ContextEmpty (tile ^. tile_terrain)
+      Fog        -> ContextFog
+      Visible    -> case tile ^. tile_content of
+        Nothing            -> ContextEmpty (tile ^. tile_terrain)
+        Just (Player unit) -> ContextPlayer unit (gs ^. game_player_inventory)
+        Just (Enemy unit)  -> ContextEnemy unit
+        Just (House unit)  -> ContextHouse unit
+        Just (Shop content) -> ContextShop content
 
 -- | Compute the set of tiles currently within sight range (distance < 5).
 computeNewlyExplored :: GameState -> Set Axial
@@ -413,6 +441,7 @@ updateLogic resetTo = \case
     let immediateAction = isShopping currentState towards
     case immediateAction of
       Just plan -> trace (show plan) $ do
+        game_selected .= Just towards
         mCombatRes <- applyAttack plan
         traverse_ (countLoot plan) mCombatRes
         modifying game_board (figureOutMove mCombatRes plan)

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -778,6 +778,31 @@ spec = do
     contextTerrain (ContextEmpty Mountains)
       `shouldBe` Just Mountains
 
+  it "ContextShopFar carries terrain" $
+    contextTerrain (ContextShopFar Water)
+      `shouldBe` Just Water
+
   it "ContextNone has no terrain" $
     contextTerrain ContextNone
       `shouldBe` Nothing
+
+ describe "Off-grid and shop distance" $ do
+  it "selecting an off-grid tile returns ContextNone" $ do
+    let gs = initialState & game_selected .~ Just (MkAxial 99 99)
+    selectedTileInfo gs `shouldBe` ContextNone
+
+  it "selecting a visible shop from far away returns ContextShopFar" $ do
+    -- Player at MkAxial 2 3, place shop at MkAxial 2 5 (distance 2: visible but not adjacent)
+    let farShopAxial = MkAxial 2 5
+        gs = initialState
+          & game_board . ix farShopAxial . tile_content ?~ Shop shopTileContent
+          & game_selected .~ Just farShopAxial
+    case selectedTileInfo gs of
+      ContextShopFar _ -> pure ()
+      other -> expectationFailure $ "Expected ContextShopFar, got: " <> show other
+
+  it "selecting a shop while adjacent returns ContextShop" $ do
+    let gs = playerAdjacentToShop & game_selected .~ Just shopAxial
+    case selectedTileInfo gs of
+      ContextShop _ _ -> pure ()
+      other -> expectationFailure $ "Expected ContextShop, got: " <> show other

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -5,9 +5,14 @@ import           Control.Monad.Trans.Random.Lazy (runRandT)
 import qualified Data.Map.Strict                 as Map
 import qualified Data.Set                        as Set
 import           Plunder.Combat (Weapon(..), isDead, unit_hp, unit_weapon, StatusEffect(..), unit_status, _DrinkingPotion, _Healing)
+import           Data.Int                        (Int32)
+import           Foreign.C.Types                 (CInt)
 import           Plunder.Grid
+import           Plunder.Mouse                   (isClickInPanel)
+import           Plunder.Render.ContextPanel      (panelHeight)
 import           Plunder.Shop
 import           Plunder.State
+import           SDL                             (MouseButtonEventData(..), InputMotion(..), MouseButton(..), MouseDevice(..), V2(..), Point(..))
 import           System.Random                   (mkStdGen)
 import           Test.Hspec
 import           Test.QuickCheck                 ()
@@ -716,3 +721,21 @@ spec = do
     case selectedTileInfo gs of
       ContextShop _ content -> content `shouldBe` shopTileContent
       other -> expectationFailure $ "Expected ContextShop, got: " <> show other
+
+ describe "isClickInPanel" $ do
+  let mkClick :: Int32 -> MouseButtonEventData
+      mkClick y = MouseButtonEventData Nothing Pressed (Mouse 0) ButtonLeft 1 (P (V2 100 y))
+      winSize :: CInt -> V2 CInt
+      winSize h = V2 640 h
+
+  it "click inside panel area returns True" $
+    isClickInPanel panelHeight (winSize 480) (mkClick 400) `shouldBe` True
+
+  it "click above panel area returns False" $
+    isClickInPanel panelHeight (winSize 480) (mkClick 300) `shouldBe` False
+
+  it "click at exact boundary returns True" $
+    isClickInPanel panelHeight (winSize 480) (mkClick 360) `shouldBe` True
+
+  it "click one pixel above boundary returns False" $
+    isClickInPanel panelHeight (winSize 480) (mkClick 359) `shouldBe` False

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -673,3 +673,46 @@ spec = do
   it "right-clicking adjacent shop sets game_selected to shop tile" $
     runEvt (RightClick shopAxial) playerAdjacentToShop ^. game_selected
       `shouldBe` Just shopAxial
+
+  it "selecting a visible house returns ContextHouse with HP and terrain" $ do
+    let houseAxial = MkAxial 3 3  -- adjacent house in initial layout
+        gs = initialState & game_selected .~ Just houseAxial
+    case selectedTileInfo gs of
+      ContextHouse terrain unit' -> do
+        terrain `shouldBe` Land
+        unit' ^. unit_hp `shouldBe` 10
+      other -> expectationFailure $ "Expected ContextHouse, got: " <> show other
+
+  it "ContextPlayer carries the player inventory" $ do
+    let item = MkShopItem 4 ShopHealthPotion
+        gs = initialState
+          & game_selected .~ Just playerAxial
+          & game_player_inventory . inventroy_item .~ Set.singleton item
+    case selectedTileInfo gs of
+      ContextPlayer _ _ inv -> inv ^. inventroy_item `shouldBe` Set.singleton item
+      other -> expectationFailure $ "Expected ContextPlayer, got: " <> show other
+
+  it "ContextEnemy carries the terrain type" $ do
+    let enemyAxial = MkAxial 2 4
+        gs = initialState
+          & game_board . ix enemyAxial . tile_content ?~ Enemy defUnit
+          & game_board . ix enemyAxial . tile_terrain .~ Water
+          & game_selected .~ Just enemyAxial
+    case selectedTileInfo gs of
+      ContextEnemy terrain _ -> terrain `shouldBe` Water
+      other -> expectationFailure $ "Expected ContextEnemy, got: " <> show other
+
+  it "ContextEmpty carries terrain type for Water tiles" $ do
+    let emptyAxial = MkAxial 2 4
+        gs = initialState
+          & game_board . ix emptyAxial . tile_terrain .~ Water
+          & game_selected .~ Just emptyAxial
+    selectedTileInfo gs `shouldBe` ContextEmpty Water
+
+  it "ContextShop carries the shop content" $ do
+    let gs = initialState
+          & game_board . at (MkAxial 2 5) . _Just . tile_content ?~ Player defUnit
+          & game_selected .~ Just shopAxial
+    case selectedTileInfo gs of
+      ContextShop _ content -> content `shouldBe` shopTileContent
+      other -> expectationFailure $ "Expected ContextShop, got: " <> show other

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -739,3 +739,45 @@ spec = do
 
   it "click one pixel above boundary returns False" $
     isClickInPanel panelHeight (winSize 480) (mkClick 359) `shouldBe` False
+
+ describe "Shop exit" $ do
+  let shopOpen = playerAdjacentToShop
+        & game_shop .~ Just shopTileContent
+        & game_selected .~ Just shopAxial
+
+  it "MkExited clears game_shop" $
+    runEvt (ShopUpdates MkExited) shopOpen ^. game_shop
+      `shouldBe` Nothing
+
+  it "MkExited clears game_selected" $
+    runEvt (ShopUpdates MkExited) shopOpen ^. game_selected
+      `shouldBe` Nothing
+
+ describe "contextTerrain" $ do
+  it "ContextPlayer carries terrain" $
+    contextTerrain (ContextPlayer Land defUnit (MkInventory 0 Set.empty))
+      `shouldBe` Just Land
+
+  it "ContextEnemy carries terrain" $
+    contextTerrain (ContextEnemy Water defUnit)
+      `shouldBe` Just Water
+
+  it "ContextHouse carries terrain" $
+    contextTerrain (ContextHouse Mountains defUnit)
+      `shouldBe` Just Mountains
+
+  it "ContextShop carries terrain" $
+    contextTerrain (ContextShop Land shopTileContent)
+      `shouldBe` Just Land
+
+  it "ContextFog carries terrain" $
+    contextTerrain (ContextFog Water)
+      `shouldBe` Just Water
+
+  it "ContextEmpty carries terrain" $
+    contextTerrain (ContextEmpty Mountains)
+      `shouldBe` Just Mountains
+
+  it "ContextNone has no terrain" $
+    contextTerrain ContextNone
+      `shouldBe` Nothing

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -619,14 +619,16 @@ spec = do
  describe "selectedTileInfo" $ do
   let playerAxial = MkAxial 2 3
 
-  it "no selection returns ContextEmpty Land" $
-    selectedTileInfo initialState `shouldBe` ContextEmpty Land
+  it "no selection returns ContextNone" $
+    selectedTileInfo initialState `shouldBe` ContextNone
 
-  it "selecting the player tile returns ContextPlayer with correct HP" $ do
+  it "selecting the player tile returns ContextPlayer with correct HP and terrain" $ do
     let gs = initialState & game_selected .~ Just playerAxial
     case selectedTileInfo gs of
-      ContextPlayer unit _inv -> unit ^. unit_hp `shouldBe` 10
-      other                   -> expectationFailure $ "Expected ContextPlayer, got: " <> show other
+      ContextPlayer terrain unit' _inv -> do
+        unit' ^. unit_hp `shouldBe` 10
+        terrain `shouldBe` Land
+      other -> expectationFailure $ "Expected ContextPlayer, got: " <> show other
 
   it "selecting a visible enemy returns ContextEnemy with correct HP" $ do
     let enemyAxial = MkAxial 2 4
@@ -634,13 +636,15 @@ spec = do
           & game_board . ix enemyAxial . tile_content ?~ Enemy defUnit
           & game_selected .~ Just enemyAxial
     case selectedTileInfo gs of
-      ContextEnemy unit -> unit ^. unit_hp `shouldBe` 10
-      other             -> expectationFailure $ "Expected ContextEnemy, got: " <> show other
+      ContextEnemy _terrain unit' -> unit' ^. unit_hp `shouldBe` 10
+      other                       -> expectationFailure $ "Expected ContextEnemy, got: " <> show other
 
-  it "fog tile returns ContextFog" $ do
+  it "fog tile returns ContextFog with terrain" $ do
     -- MkAxial 5 3 is at distance 3 from player, which is Fog
     let gs = initialState & game_selected .~ Just (MkAxial 5 3)
-    selectedTileInfo gs `shouldBe` ContextFog
+    case selectedTileInfo gs of
+      ContextFog Land -> pure ()
+      other           -> expectationFailure $ "Expected ContextFog Land, got: " <> show other
 
   it "visible shop tile returns ContextShop" $ do
     -- Shop at MkAxial 2 6 is visible when player is adjacent at MkAxial 2 5
@@ -648,8 +652,8 @@ spec = do
           & game_board . at (MkAxial 2 5) . _Just . tile_content ?~ Player defUnit
           & game_selected .~ Just shopAxial
     case selectedTileInfo gs of
-      ContextShop _ -> pure ()
-      other         -> expectationFailure $ "Expected ContextShop, got: " <> show other
+      ContextShop _ _ -> pure ()
+      other           -> expectationFailure $ "Expected ContextShop, got: " <> show other
 
   it "enemy in fog returns ContextFog not ContextEnemy" $ do
     -- Place enemy at a foggy distance
@@ -657,7 +661,14 @@ spec = do
         gs = initialState
           & game_board . ix fogAxial . tile_content ?~ Enemy defUnit
           & game_selected .~ Just fogAxial
-    selectedTileInfo gs `shouldBe` ContextFog
+    case selectedTileInfo gs of
+      ContextFog _ -> pure ()
+      other        -> expectationFailure $ "Expected ContextFog, got: " <> show other
+
+  it "empty visible tile returns ContextEmpty with terrain" $ do
+    let emptyAxial = MkAxial 2 4  -- adjacent to player, empty
+        gs = initialState & game_selected .~ Just emptyAxial
+    selectedTileInfo gs `shouldBe` ContextEmpty Land
 
   it "right-clicking adjacent shop sets game_selected to shop tile" $
     runEvt (RightClick shopAxial) playerAdjacentToShop ^. game_selected

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -615,3 +615,50 @@ spec = do
   it "ResetGame re-initializes explored set" $ do
     let result = runEvt ResetGame (initialState & game_phase .~ YouDied)
     Set.member playerAxial (result ^. game_explored) `shouldBe` True
+
+ describe "selectedTileInfo" $ do
+  let playerAxial = MkAxial 2 3
+
+  it "no selection returns ContextEmpty Land" $
+    selectedTileInfo initialState `shouldBe` ContextEmpty Land
+
+  it "selecting the player tile returns ContextPlayer with correct HP" $ do
+    let gs = initialState & game_selected .~ Just playerAxial
+    case selectedTileInfo gs of
+      ContextPlayer unit _inv -> unit ^. unit_hp `shouldBe` 10
+      other                   -> expectationFailure $ "Expected ContextPlayer, got: " <> show other
+
+  it "selecting a visible enemy returns ContextEnemy with correct HP" $ do
+    let enemyAxial = MkAxial 2 4
+        gs = initialState
+          & game_board . ix enemyAxial . tile_content ?~ Enemy defUnit
+          & game_selected .~ Just enemyAxial
+    case selectedTileInfo gs of
+      ContextEnemy unit -> unit ^. unit_hp `shouldBe` 10
+      other             -> expectationFailure $ "Expected ContextEnemy, got: " <> show other
+
+  it "fog tile returns ContextFog" $ do
+    -- MkAxial 5 3 is at distance 3 from player, which is Fog
+    let gs = initialState & game_selected .~ Just (MkAxial 5 3)
+    selectedTileInfo gs `shouldBe` ContextFog
+
+  it "visible shop tile returns ContextShop" $ do
+    -- Shop at MkAxial 2 6 is visible when player is adjacent at MkAxial 2 5
+    let gs = initialState
+          & game_board . at (MkAxial 2 5) . _Just . tile_content ?~ Player defUnit
+          & game_selected .~ Just shopAxial
+    case selectedTileInfo gs of
+      ContextShop _ -> pure ()
+      other         -> expectationFailure $ "Expected ContextShop, got: " <> show other
+
+  it "enemy in fog returns ContextFog not ContextEnemy" $ do
+    -- Place enemy at a foggy distance
+    let fogAxial = MkAxial 5 3  -- distance 3 from player = Fog
+        gs = initialState
+          & game_board . ix fogAxial . tile_content ?~ Enemy defUnit
+          & game_selected .~ Just fogAxial
+    selectedTileInfo gs `shouldBe` ContextFog
+
+  it "right-clicking adjacent shop sets game_selected to shop tile" $
+    runEvt (RightClick shopAxial) playerAdjacentToShop ^. game_selected
+      `shouldBe` Just shopAxial


### PR DESCRIPTION
## Summary
- Added a bottom-of-screen context panel that shows info about the clicked tile (Player HP/weapon/gold, Enemy HP/weapon, House HP, Shop interactive purchase, Fog label)
- Replaced the floating shop window with shop embedded in the context panel
- Added pure `ContextInfo` type + `selectedTileInfo` function in `State.hs` for testable tile-info derivation
- 7 new tests covering all `selectedTileInfo` cases (no selection, player, enemy, fog, shop, enemy-in-fog, right-click shop sets selected)

## Test plan
- [x] `nix-build default.nix` passes (122 examples, 0 failures, no new warnings)
- [ ] Manual: click player tile → panel shows Player with HP, weapon, gold
- [ ] Manual: click enemy tile → panel shows Enemy with HP, weapon
- [ ] Manual: click fog tile → panel shows "Fog of war"
- [ ] Manual: right-click adjacent shop → panel shows shop with items, purchase/exit buttons
- [ ] Manual: click empty tile → panel disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)