### PR TITLE
Refactor: replace MonadReader Renderer with RenderFun record

### DIFF
--- a/game13.cabal
+++ b/game13.cabal
@@ -36,6 +36,7 @@ library
       Plunder.Render
       Plunder.Render.ContextPanel
       Plunder.Render.Color
+      Plunder.Render.RenderFun
       Plunder.Render.Font
       Plunder.Render.Health
       Plunder.Render.Help

--- a/src/Plunder.hs
+++ b/src/Plunder.hs
@@ -15,15 +15,15 @@ import           Reflex
 import           Reflex.SDL2
 import           Plunder.Guest
 import           Plunder.Level (decodeLevelFile)
+import           Plunder.Render.RenderFun (RenderFun, mkRenderFun)
 import           Plunder.State (GameState, levelToGameState)
 import           qualified SDL.Font as Font
 
-app :: (ReflexSDL2 t m, MonadReader Renderer m) => GameState -> m ()
-app initGS = do
+app :: (ReflexSDL2 t m, MonadReader RenderFun m) => Renderer -> GameState -> m ()
+app r initGS = do
   (_, dynLayers) <- runDynamicWriterT $ do
     guest initGS
     onQuit
-  r <- ask
   performEvent_ $ ffor (updated dynLayers) $ \layers -> do
     rendererDrawColor r $= V4 0 0 0 255
     clear r
@@ -60,7 +60,7 @@ main = do
   rendererDrawBlendMode r $= BlendAlphaBlend
   -- Host the network with an example of how to embed your own effects.
   -- In this case it's a simple reader.
-  host $ (runReaderT (app initGS) r)
+  host $ runReaderT (app r initGS) (mkRenderFun r)
   destroyRenderer r
   destroyWindow window
   quit

--- a/src/Plunder.hs
+++ b/src/Plunder.hs
@@ -15,20 +15,21 @@ import           Reflex
 import           Reflex.SDL2
 import           Plunder.Guest
 import           Plunder.Level (decodeLevelFile)
-import           Plunder.Render.RenderFun (RenderFun, mkRenderFun)
+import           Plunder.Render.RenderFun (RenderFun(..), mkRenderFun)
 import           Plunder.State (GameState, levelToGameState)
 import           qualified SDL.Font as Font
 
-app :: (ReflexSDL2 t m, MonadReader RenderFun m) => Renderer -> GameState -> m ()
-app r initGS = do
+app :: (ReflexSDL2 t m, MonadReader RenderFun m) => GameState -> m ()
+app initGS = do
   (_, dynLayers) <- runDynamicWriterT $ do
     guest initGS
     onQuit
+  MkRenderFun{rf_clear, rf_present, rf_setRendererDrawColor} <- ask
   performEvent_ $ ffor (updated dynLayers) $ \layers -> do
-    rendererDrawColor r $= V4 0 0 0 255
-    clear r
+    rf_setRendererDrawColor (V4 0 0 0 255)
+    rf_clear
     sequence_ layers
-    present r
+    rf_present
 
 main :: IO ()
 main = do
@@ -60,7 +61,7 @@ main = do
   rendererDrawBlendMode r $= BlendAlphaBlend
   -- Host the network with an example of how to embed your own effects.
   -- In this case it's a simple reader.
-  host $ runReaderT (app r initGS) (mkRenderFun r)
+  host $ runReaderT (app initGS) (mkRenderFun r)
   destroyRenderer r
   destroyWindow window
   quit

--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -7,7 +7,8 @@ module Plunder.Guest(guest) where
 
 import           Control.Lens
 import           Control.Monad                   (forM_, void)
-import           Control.Monad.Reader            (MonadReader (..))
+import           Control.Monad.Reader            (MonadReader)
+import           Plunder.Render.RenderFun       (RenderFun)
 import           Data.Word                       (Word8)
 import           Foreign.C.Types                 (CInt)
 import           Control.Monad.Trans.Random.Lazy
@@ -31,7 +32,7 @@ import Control.Concurrent (forkIO, threadDelay)
 guest
   :: forall t m
    . ReflexSDL2 t m
-  => DynamicWriter t [Layer m] m => MonadReader Renderer m => GameState -> m ()
+  => DynamicWriter t [Layer m] m => MonadReader RenderFun m => GameState -> m ()
 guest initGS = mdo
   -- Print some stuff after the network is built.
   evPB           <- getPostBuild

--- a/src/Plunder/Render.hs
+++ b/src/Plunder/Render.hs
@@ -8,7 +8,9 @@ import Plunder.Render.Text
 import           Plunder.Combat
 import           Control.Lens
 import           Control.Monad
-import           Control.Monad.Reader (MonadReader (..))
+import           Control.Monad.Reader (MonadReader (..)
+                                     )
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Foreign.C.Types      (CInt)
 import qualified Data.Map.Strict      as Map
 import qualified Data.Text            as T
@@ -25,19 +27,18 @@ import           Plunder.Render.Image
 import           Plunder.Render.Layer
 import           Plunder.Render.Terrain
 import           Plunder.State
-import           Plunder.Render.Color
 import           Plunder.Render.Font
 
 renderState :: ReflexSDL2 t m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => DynamicWriter t [Layer m] m
   => Font ->  Dynamic t GameState -> m ()
 renderState font state = do
-  renderer <- ask
+  rf <- ask
 
   -- Terrain fill is the very first (lowest) layer: coloured hexagons for
   -- every coordinate in range, with Water used for anything outside the grid.
-  renderTerrain renderer (view game_board <$> state)
+  renderTerrain rf (view game_board <$> state)
 
   vikingF <- renderImage <$> loadViking
   enemyF <- renderImage <$> loadEnemy
@@ -77,18 +78,18 @@ renderState font state = do
   -- Draw planned-move arrows on top of units
   commitLayer $ ffor (view game_planned_moves <$> state) $ \plans ->
     for_ (Map.toList plans) $ \(src, path) ->
-      drawPathArrows renderer axialToPixel src path (V4 255 165 0 255)
+      drawPathArrows rf axialToPixel src path (V4 255 165 0 255)
 
   -- Fog of war overlay (covers terrain, sprites and arrows, but not HUD)
-  renderFogOverlay renderer state
+  renderFogOverlay rf state
 
   let moneyStyle :: Style
       moneyStyle = defaultStyle & styleColorLens .~ V4 255 215 0 255
       moneyBgRect :: Rectangle CInt
       moneyBgRect = Rectangle (P $ V2 492 4) (V2 142 28)
   commitLayer $ pure $ do
-    setDrawColor renderer (V4 0 0 0 200)
-    fillRect renderer (Just moneyBgRect)
+    rf_setDrawColor rf (V4 0 0 0 200)
+    rf_fillRect rf (Just moneyBgRect)
   void $ imageEvt =<< dynView (state <&>
     \state' ->
       renderText font moneyStyle (P $ V2 500 10)
@@ -112,7 +113,7 @@ renderState font state = do
 
 applyImage ::
   DynamicWriter t [Performable m ()] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => ReflexSDL2 t m
   => (Axial -> ImageSettings)
   -> Getting Any Tile a -- ^ condition on the tile for rendering

--- a/src/Plunder/Render/Arrow.hs
+++ b/src/Plunder/Render/Arrow.hs
@@ -2,23 +2,24 @@ module Plunder.Render.Arrow (drawArrow, drawPathArrows) where
 
 import           Control.Monad.IO.Class (MonadIO)
 import           Foreign.C.Types        (CInt)
-import           Reflex.SDL2            (Renderer, V2 (..), Point (..))
-import           SDL.Primitive          (Color, fillTriangle, thickLine)
+import           Reflex.SDL2            (V2 (..), Point (..))
+import           SDL.Primitive          (Color)
+import           Plunder.Render.RenderFun (RenderFun(..))
 
 -- | Draw an arrow (thick shaft + filled arrowhead) from one pixel position
 --   to another.  Does nothing when the two points coincide.
 drawArrow
   :: MonadIO m
-  => Renderer
+  => RenderFun
   -> Point V2 CInt  -- ^ from
   -> Point V2 CInt  -- ^ to
   -> Color
   -> m ()
-drawArrow renderer (P (V2 fx fy)) (P (V2 tx ty)) color
+drawArrow rf (P (V2 fx fy)) (P (V2 tx ty)) color
   | fx == tx && fy == ty = pure ()
   | otherwise = do
-      thickLine renderer (V2 fx fy) (V2 tx ty) 3 color
-      fillTriangle renderer tip wing1 wing2 color
+      rf_thickLine rf (V2 fx fy) (V2 tx ty) 3 color
+      rf_fillTriangle rf tip wing1 wing2 color
   where
     dx, dy, len, ux, uy :: Double
     dx  = fromIntegral (tx - fx)
@@ -49,17 +50,17 @@ drawArrow renderer (P (V2 fx fy)) (P (V2 tx ty)) color
 --   @src@ is the starting tile; @waypoints@ is the path (excluding src).
 drawPathArrows
   :: MonadIO m
-  => Renderer
+  => RenderFun
   -> (a -> Point V2 CInt)  -- ^ convert a coordinate to pixel position
   -> a                     -- ^ source coordinate
   -> [a]                   -- ^ path waypoints (excluding source)
   -> Color
   -> m ()
-drawPathArrows renderer toPixel src waypoints color =
+drawPathArrows rf toPixel src waypoints color =
   go (toPixel src) waypoints
   where
     go _ []     = pure ()
     go from (w:ws) = do
       let to = toPixel w
-      drawArrow renderer from to color
+      drawArrow rf from to color
       go to ws

--- a/src/Plunder/Render/Banner.hs
+++ b/src/Plunder/Render/Banner.hs
@@ -5,9 +5,9 @@ module Plunder.Render.Banner(renderBanner) where
 
 import           Control.Lens
 import           Control.Monad.Reader (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.Word            (Word8)
 import           Foreign.C.Types      (CInt)
-import           Plunder.Render.Color
 import           Plunder.Render.Font
 import           Plunder.Render.Image
 import           Plunder.Render.Layer
@@ -33,10 +33,10 @@ msgStyle = defaultStyle
 renderBanner
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Dynamic t GamePhase -> Dynamic t Word8 -> Dynamic t (V2 CInt) -> m ()
 renderBanner font phaseDyn alphaDyn winSizeDyn = do
-  renderer <- ask
+  MkRenderFun{rf_setDrawColor, rf_fillRect, rf_copy} <- ask
   -- Pre-allocate text textures once; never recreated per frame.
   diedImg <- allocateText font msgStyle "YOU DIED"
   victImg <- allocateText font msgStyle "YOU ARE VICTORIOUS"
@@ -53,7 +53,7 @@ renderBanner font phaseDyn alphaDyn winSizeDyn = do
           bannerRect = Rectangle
             (P $ V2 ((w - bannerW) `div` 2) ((h - bannerH) `div` 2))
             (V2 bannerW bannerH)
-      setDrawColor renderer (V4 20 20 20 alpha)
-      fillRect renderer (Just bannerRect)
+      rf_setDrawColor (V4 20 20 20 alpha)
+      rf_fillRect (Just bannerRect)
       textureAlphaMod tex $= alpha
-      copy renderer tex Nothing (Just $ img ^. image_position)
+      rf_copy tex Nothing (Just $ img ^. image_position)

--- a/src/Plunder/Render/ContextPanel.hs
+++ b/src/Plunder/Render/ContextPanel.hs
@@ -10,6 +10,7 @@ module Plunder.Render.ContextPanel(
 import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Reader (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.Text (Text)
 import qualified Data.Map as Map
 import           Data.Map (Map)
@@ -19,7 +20,6 @@ import           Data.Word (Word8, Word64)
 import           Foreign.C.Types (CInt)
 import           Plunder.Combat
 import           Plunder.Grid (Terrain(..))
-import           Plunder.Render.Color
 import           Plunder.Render.Font
 import           Plunder.Render.Image
 import           Plunder.Render.Layer
@@ -48,22 +48,22 @@ shopSelectedStyle = panelStyle & styleColorLens .~ V4 200 30 30 255
 renderContextPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Dynamic t GameState -> Dynamic t (V2 CInt) -> m (Event t ShopAction)
 renderContextPanel font gameState winSizeDyn = do
   let contextDyn = selectedTileInfo <$> gameState
       moneyDyn   = view (game_player_inventory . inventory_money) <$> gameState
       hasRoomDyn = isJust . findFreeAdjacent <$> gameState
 
-  renderer <- ask
+  MkRenderFun{rf_setDrawColor, rf_fillRect} <- ask
 
   -- Draw dark panel background
   commitLayer $ ffor2 contextDyn winSizeDyn $ \ctx (V2 w h) ->
     case ctx of
       ContextNone -> pure ()
       _           -> do
-        setDrawColor renderer (V4 30 30 30 220)
-        fillRect renderer (Just (Rectangle (P $ V2 0 (h - panelHeight)) (V2 w panelHeight)))
+        rf_setDrawColor (V4 30 30 30 220)
+        rf_fillRect (Just (Rectangle (P $ V2 0 (h - panelHeight)) (V2 w panelHeight)))
 
   -- Render content using dynView; switchHold flattens the shop events
   shopEvtEvt <- dynView $ renderPanelContent font winSizeDyn moneyDyn hasRoomDyn <$> contextDyn
@@ -78,7 +78,7 @@ panelPos (V2 _ h) xOff lineIdx =
 panelText
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Style -> Point V2 CInt -> Text -> m ()
 panelText font style pos txt = do
   imgSettings <- renderText font style pos txt
@@ -87,7 +87,7 @@ panelText font style pos txt = do
 renderPanelContent
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ContextInfo -> m (Event t ShopAction)
 renderPanelContent _ _ _ _ ContextNone = pure never
 renderPanelContent font winSizeDyn _ _ (ContextEmpty terrain) = do
@@ -127,7 +127,7 @@ contentXOff = 120
 renderEmptyPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Terrain -> V2 CInt -> m ()
 renderEmptyPanel font terrain winSize = do
   panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
@@ -136,7 +136,7 @@ renderEmptyPanel font terrain winSize = do
 renderFogPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Terrain -> V2 CInt -> m ()
 renderFogPanel font terrain winSize = do
   panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
@@ -145,7 +145,7 @@ renderFogPanel font terrain winSize = do
 renderPlayerPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Terrain -> Unit -> PlayerInventory -> V2 CInt -> m ()
 renderPlayerPanel font terrain unit' inv winSize = do
   panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
@@ -164,7 +164,7 @@ renderPlayerPanel font terrain unit' inv winSize = do
 renderEnemyPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Terrain -> Unit -> V2 CInt -> m ()
 renderEnemyPanel font terrain unit' winSize = do
   panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
@@ -179,7 +179,7 @@ renderEnemyPanel font terrain unit' winSize = do
 renderHousePanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Terrain -> Unit -> V2 CInt -> m ()
 renderHousePanel font terrain unit' winSize = do
   panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
@@ -190,7 +190,7 @@ renderHousePanel font terrain unit' winSize = do
 renderShopFarPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Terrain -> V2 CInt -> m ()
 renderShopFarPanel font terrain winSize = do
   panelText font panelHeaderStyle (panelPos winSize 0 0) (terrainLabel terrain)
@@ -246,7 +246,7 @@ purchaseAction playerMoney hasRoom sel content =
 renderShopPanel
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Terrain -> Dynamic t (V2 CInt) -> Dynamic t Word64 -> Dynamic t Bool -> ShopContent -> m (Event t ShopAction)
 renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content = mdo
   -- Terrain (left) and header (right)
@@ -290,13 +290,13 @@ renderShopPanel font terrain winSizeDyn moneyDyn hasRoomDyn content = mdo
   pure $ leftmost [MkBought <$> purchaseSuccess, MkExited <$ exitClick]
 
 renderErrorText
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  :: (ReflexSDL2 t m, MonadReader RenderFun m)
   => Font -> Maybe PurchaseError -> Maybe (m ImageSettings)
 renderErrorText _ Nothing = Nothing
 renderErrorText small (Just err) = Just $ renderText small panelStyle (P $ V2 300 10) (renderPurchaseError err)
 
 renderShopSlot
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  :: (ReflexSDL2 t m, MonadReader RenderFun m)
   => Font -> ShopContent -> Word8 -> (ShopContent -> Maybe ShopItem) -> V2 CInt -> ShopSelection -> m (Maybe ImageSettings)
 renderShopSlot font content idx slotAccessor winSize sel = do
   let style = if Map.member idx (selectedSlots sel) then shopSelectedStyle else panelStyle

--- a/src/Plunder/Render/Health.hs
+++ b/src/Plunder/Render/Health.hs
@@ -6,6 +6,7 @@ import           Control.Lens
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader   (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.Maybe
 import           Foreign.C.Types        (CInt)
 import           Plunder.Grid
@@ -13,15 +14,14 @@ import           Reflex
 import           Reflex.SDL2
 import           Plunder.Render.Layer
 import SDL.Primitive(Color)
-import Plunder.Render.Color
 
 healthBar :: DynamicWriter t [Layer m] m
         => ReflexSDL2 t m
-        => MonadReader Renderer m
+        => MonadReader RenderFun m
         => Dynamic t Tile -> m ()
 healthBar tileDyn = do
-  renderer    <- ask
-  commitLayer $ healthBar' renderer <$> tileDyn
+  rf <- ask
+  commitLayer $ healthBar' rf <$> tileDyn
 
 barHeight :: Num a => a
 barHeight = 6
@@ -42,17 +42,17 @@ borderColor :: Color
 borderColor = V4 0 0 0 255
 
 healthBar' :: MonadIO m
-        => Renderer -> Tile -> m ()
-healthBar' renderer tile = unless isDead $ do
+        => RenderFun -> Tile -> m ()
+healthBar' rf tile = unless isDead $ do
     -- dark background (full max-health width)
-    setDrawColor renderer bgColor
-    fillRect renderer $ Just bgRect
+    rf_setDrawColor rf bgColor
+    rf_fillRect rf $ Just bgRect
     -- green health fill
-    setDrawColor renderer fillColor
-    fillRect renderer $ Just fillRect'
+    rf_setDrawColor rf fillColor
+    rf_fillRect rf $ Just fillRect'
     -- black border on top
-    setDrawColor renderer borderColor
-    drawRect renderer $ Just bgRect
+    rf_setDrawColor rf borderColor
+    rf_drawRect rf $ Just bgRect
     where
       isDead :: Bool
       isDead = fromMaybe True $ do

--- a/src/Plunder/Render/Help.hs
+++ b/src/Plunder/Render/Help.hs
@@ -5,10 +5,10 @@ module Plunder.Render.Help(renderHelp) where
 import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Reader (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.List            (foldl')
 import           Data.Text            (Text)
 import           Foreign.C.Types      (CInt)
-import           Plunder.Render.Color
 import           Plunder.Render.Font
 import           Plunder.Render.Image (ImageSettings (..), image, image_position)
 import           Plunder.Render.Layer
@@ -65,7 +65,7 @@ data RenderedLine
   | RenderedBlank
 
 allocateLine
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  :: (ReflexSDL2 t m, MonadReader RenderFun m)
   => Font -> HelpLine -> m RenderedLine
 allocateLine font (HelpHeader t) = RenderedSingle <$> allocateText font (toStyle Header) t <*> pure Header
 allocateLine font (HelpRow k d)  = RenderedPair <$> allocateText font (toStyle Body) k
@@ -90,10 +90,10 @@ keyColumnWidth = foldl' maxKey 0
 renderHelp
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Dynamic t Bool -> Dynamic t (V2 CInt) -> m (Event t ())
 renderHelp font isOpen winSizeDyn = do
-  renderer <- ask
+  MkRenderFun{rf_setDrawColor, rf_fillRect, rf_drawRect, rf_copy} <- ask
   rendered <- forM helpLines $ allocateLine font
   okSurface <- allocateText font (toStyle Body) "[ OK ]"
   let V2 okW okH = textSurfaceSize okSurface
@@ -112,19 +112,19 @@ renderHelp font isOpen winSizeDyn = do
         bgY = (h - bgH) `div` 2
         textX = bgX + textPadX
         textY idx = bgY + textPadY + fromIntegral idx * lineH
-    setDrawColor renderer (V4 210 210 210 245)
-    fillRect renderer $ Just (Rectangle (P $ V2 bgX bgY) (V2 bgW bgH))
-    setDrawColor renderer (V4 0 0 0 255)
-    drawRect renderer $ Just (Rectangle (P $ V2 bgX bgY) (V2 bgW bgH))
+    rf_setDrawColor (V4 210 210 210 245)
+    rf_fillRect $ Just (Rectangle (P $ V2 bgX bgY) (V2 bgW bgH))
+    rf_setDrawColor (V4 0 0 0 255)
+    rf_drawRect $ Just (Rectangle (P $ V2 bgX bgY) (V2 bgW bgH))
     forM_ (zip [(0 :: Int) ..] rendered) $ \(idx, rl) -> case rl of
       RenderedSingle surf _ -> do
         let img = surfaceToSettings surf (P $ V2 textX (textY idx))
-        copy renderer (_image_content img) Nothing (Just $ img ^. image_position)
+        rf_copy (_image_content img) Nothing (Just $ img ^. image_position)
       RenderedPair keySurf descSurf -> do
         let kImg = surfaceToSettings keySurf (P $ V2 textX (textY idx))
             dImg = surfaceToSettings descSurf (P $ V2 (bgX + descX) (textY idx))
-        copy renderer (_image_content kImg) Nothing (Just $ kImg ^. image_position)
-        copy renderer (_image_content dImg) Nothing (Just $ dImg ^. image_position)
+        rf_copy (_image_content kImg) Nothing (Just $ kImg ^. image_position)
+        rf_copy (_image_content dImg) Nothing (Just $ dImg ^. image_position)
       RenderedBlank -> pure ()
   okClicks <- image okImgDyn
   pure (() <$ okClicks)

--- a/src/Plunder/Render/Hexagon.hs
+++ b/src/Plunder/Render/Hexagon.hs
@@ -22,6 +22,7 @@ import           SDL.Font(Font)
 import           Plunder.Render.Text
 import           Control.Lens
 import           Control.Monad.Reader (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.Foldable
 import           Data.Int
 import           Data.Text            (Text)
@@ -33,7 +34,7 @@ import           Reflex
 import           Reflex.SDL2
 import           Plunder.Render.Image
 import           Plunder.Render.Layer
-import           SDL.Primitive (polygon, fillPolygon, Color)
+import           SDL.Primitive (Color)
 import           Text.Printf
 
 data HexagonSettings = HexagonSettings
@@ -105,13 +106,15 @@ calcPoints settings =
 -- 3. detect click. https://www.redblobgames.com/grids/hexagons/#pixel-to-hex
 hexagon
   :: ReflexSDL2 t m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => DynamicWriter t [Layer m] m => HexagonSettings -> m ()
 hexagon settings = do
-  r    <- ask
+  MkRenderFun{rf_fillPolygon, rf_polygon} <- ask
+  let polgyonF = if settings ^. hexagon_is_filled then rf_fillPolygon else rf_polygon
+      (xPoints, yPoints) = calcPoints settings
   evPB <- holdDyn () =<< getPostBuild
   commitLayer $ ffor evPB $ const $ do
-    polgyonF r xPoints yPoints $ settings ^. hexagon_color
+    polgyonF xPoints yPoints $ settings ^. hexagon_color
   for_ (settings ^. hexagon_label) $ \text -> do
       imageSettings <- renderText (settings ^. hexagon_font) (MkStyle
                                                                 { styleHorizontalAlign = Center
@@ -119,9 +122,6 @@ hexagon settings = do
                                                                 }) (settings ^. hexagon_position) text
       image $ pure $ Just imageSettings
   pure ()
-  where
-    (xPoints, yPoints) = calcPoints settings
-    polgyonF = if settings ^. hexagon_is_filled then fillPolygon else polygon
 
 -- https://www.redblobgames.com/grids/hexagons/#hex-to-pixel
 renderHex :: Font -> Axial -> HexagonSettings

--- a/src/Plunder/Render/Image.hs
+++ b/src/Plunder/Render/Image.hs
@@ -28,6 +28,7 @@ import Control.Monad
 import           Control.Lens
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader   (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.ByteString        hiding (copy)
 import           Data.FileEmbed
 import           Foreign.C.Types        (CInt)
@@ -38,38 +39,49 @@ import           Reflex.SDL2
 import           SDL.Image
 import Plunder.Mouse
 
-loadAxe :: MonadIO m => MonadReader Renderer m => m Texture
-loadAxe = flip decodeTexture imgFile =<< ask
+loadAxe :: MonadIO m => MonadReader RenderFun m => m Texture
+loadAxe = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgFile
   where
   imgFile :: ByteString
   imgFile = $(embedFile "assets/img/axe.png")
 
-loadSword :: MonadIO m => MonadReader Renderer m => m Texture
-loadSword = flip decodeTexture imgFile =<< ask
+loadSword :: MonadIO m => MonadReader RenderFun m => m Texture
+loadSword = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgFile
   where
   imgFile :: ByteString
   imgFile = $(embedFile "assets/img/sword.png")
 
-loadBow :: MonadIO m => MonadReader Renderer m => m Texture
-loadBow = flip decodeTexture imgFile =<< ask
+loadBow :: MonadIO m => MonadReader RenderFun m => m Texture
+loadBow = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgFile
   where
   imgFile :: ByteString
   imgFile = $(embedFile "assets/img/bow.png")
 
-loadViking :: MonadIO m => MonadReader Renderer m => m Texture
-loadViking = flip decodeTexture imgFile =<< ask
+loadViking :: MonadIO m => MonadReader RenderFun m => m Texture
+loadViking = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgFile
   where
   imgFile :: ByteString
   imgFile = $(embedFile "assets/img/viking.png")
 
-loadBlood :: MonadIO m => MonadReader Renderer m => m Texture
-loadBlood = flip decodeTexture imgFile =<< ask
+loadBlood :: MonadIO m => MonadReader RenderFun m => m Texture
+loadBlood = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgFile
   where
   imgFile :: ByteString
   imgFile = $(embedFile "assets/img/blood.png")
 
-burndedHouse :: MonadIO m => MonadReader Renderer m => m Texture
+burndedHouse :: MonadIO m => MonadReader RenderFun m => m Texture
 burndedHouse = do
+  MkRenderFun{rf_createTexture} <- ask
   fire <- decode imgFireFile
   dimsFire <- surfaceDimensions fire
   house <- decode imgHouseFile
@@ -80,8 +92,7 @@ burndedHouse = do
     ry <- liftIO $ randomRIO (-(dimsFire ^. _y), (dims ^. _y) - (dimsFire ^. _y))
     surfaceBlit fire Nothing house (Just $ P $ V2 rx ry)
 
-  r1 <- ask
-  text <- createTextureFromSurface r1 house
+  text <- rf_createTexture house
 
   freeSurface house
   freeSurface fire
@@ -91,20 +102,26 @@ burndedHouse = do
 imgFireFile :: ByteString
 imgFireFile = $(embedFile "assets/img/fire.png")
 
-loadHouse :: MonadIO m => MonadReader Renderer m => m Texture
-loadHouse = flip decodeTexture imgHouseFile =<< ask
+loadHouse :: MonadIO m => MonadReader RenderFun m => m Texture
+loadHouse = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgHouseFile
 
 imgHouseFile :: ByteString
 imgHouseFile = $(embedFile "assets/img/house.png")
 
-loadShop :: MonadIO m => MonadReader Renderer m => m Texture
-loadShop = flip decodeTexture imgShopFile =<< ask
+loadShop :: MonadIO m => MonadReader RenderFun m => m Texture
+loadShop = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgShopFile
 
 imgShopFile :: ByteString
 imgShopFile = $(embedFile "assets/img/shop.png")
 
-loadEnemy :: MonadIO m => MonadReader Renderer m => m Texture
-loadEnemy = flip decodeTexture imgFile =<< ask
+loadEnemy :: MonadIO m => MonadReader RenderFun m => m Texture
+loadEnemy = do
+  MkRenderFun{rf_decodeTexture} <- ask
+  rf_decodeTexture imgFile
   where
   imgFile :: ByteString
   imgFile = $(embedFile "assets/img/male_adventurer_idle.png")
@@ -116,7 +133,7 @@ data ImageSettings = ImageSettings
 makeLenses ''ImageSettings
 
 imageEvt :: ReflexSDL2 t m
-    => MonadReader Renderer m
+    => MonadReader RenderFun m
     => DynamicWriter t [Layer m] m
     =>
   Event t ImageSettings -> m (Event t ImageActions)
@@ -127,15 +144,15 @@ data ImageActions = LeftClick
   deriving Show
 
 image :: forall t m . ReflexSDL2 t m
-    => MonadReader Renderer m
+    => MonadReader RenderFun m
     => DynamicWriter t [Layer m] m
     => Dynamic t (Maybe ImageSettings) -> m (Event t ImageActions)
 image settingsDyn = do
-  renderer    <- ask
+  MkRenderFun{rf_copy} <- ask
 
   commitLayer $ ffor settingsDyn $ \msettings ->
     flip (maybe (pure ())) msettings $ \settings -> do
-      copy renderer (settings ^. image_content) Nothing $
+      rf_copy (settings ^. image_content) Nothing $
         settings ^? image_position
 
 

--- a/src/Plunder/Render/Inventory.hs
+++ b/src/Plunder/Render/Inventory.hs
@@ -6,10 +6,10 @@ module Plunder.Render.Inventory(renderInventory) where
 import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Reader (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.Set             (Set)
 import qualified Data.Set             as Set
 import           Foreign.C.Types      (CInt)
-import           Plunder.Render.Color
 import           Plunder.Render.Font
 import           Plunder.Render.Image
 import           Plunder.Render.Layer
@@ -24,12 +24,12 @@ maxSlots = 8
 renderInventory
   :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Dynamic t Bool -> Dynamic t (Set ShopItem) -> m (Event t ShopItem)
 renderInventory font isOpen items = do
-  renderer <- ask
+  rf <- ask
 
-  commitLayer $ renderInventoryBackground renderer <$> isOpen
+  commitLayer $ renderInventoryBackground rf <$> isOpen
 
   titleSurface <- allocateText font inventoryStyle "Inventory"
   void $ image $
@@ -50,7 +50,7 @@ padTo n xs =
   in map Just taken ++ replicate (n - length taken) Nothing
 
 renderSlot
-  :: (ReflexSDL2 t m, MonadReader Renderer m)
+  :: (ReflexSDL2 t m, MonadReader RenderFun m)
   => Font -> Int -> Bool -> Maybe ShopItem -> m (Maybe ImageSettings)
 renderSlot _ _ False _ = pure Nothing
 renderSlot font idx True mItem =
@@ -64,8 +64,8 @@ inventoryStyle = defaultStyle & styleColorLens .~ V4 0 0 0 255
 invPosition :: Int -> Point V2 CInt
 invPosition offset = P $ V2 250 (20 + fromIntegral offset * 20)
 
-renderInventoryBackground :: MonadIO m => Renderer -> Bool -> m ()
-renderInventoryBackground renderer open = do
-  setDrawColor renderer $ V4 200 200 200 255
+renderInventoryBackground :: MonadIO m => RenderFun -> Bool -> m ()
+renderInventoryBackground rf open = do
+  rf_setDrawColor rf $ V4 200 200 200 255
   when open $
-    fillRect renderer (Just (Rectangle (P $ V2 240 20) (V2 200 200)))
+    rf_fillRect rf (Just (Rectangle (P $ V2 240 20) (V2 200 200)))

--- a/src/Plunder/Render/RenderFun.hs
+++ b/src/Plunder/Render/RenderFun.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | Abstraction over SDL 'Renderer' for testability.
+--   Production code uses 'mkRenderFun' to partially apply the real renderer;
+--   tests can supply a mock that captures render calls.
+module Plunder.Render.RenderFun
+  ( RenderFun(..)
+  , mkRenderFun
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO)
+import           Data.ByteString        (ByteString)
+import           Data.Int               (Int16)
+import qualified Data.Vector.Storable   as S
+import           Foreign.C.Types        (CInt)
+import           Reflex.SDL2            (Rectangle, Renderer, Surface, Texture,
+                                         V2, copy, createTextureFromSurface,
+                                         drawRect, fillRect)
+import           SDL.Primitive          (Color, fillPolygon, fillTriangle,
+                                         polygon, thickLine)
+import           SDL.Image              (decodeTexture)
+import           Plunder.Render.Color   (setDrawColor)
+
+data RenderFun = MkRenderFun
+  { rf_fillRect      :: forall m. MonadIO m => Maybe (Rectangle CInt) -> m ()
+  , rf_drawRect      :: forall m. MonadIO m => Maybe (Rectangle CInt) -> m ()
+  , rf_setDrawColor  :: forall m. MonadIO m => Color -> m ()
+  , rf_copy          :: forall m. MonadIO m => Texture -> Maybe (Rectangle CInt)
+                                            -> Maybe (Rectangle CInt) -> m ()
+  , rf_fillPolygon   :: forall m. MonadIO m => S.Vector Int16 -> S.Vector Int16
+                                            -> Color -> m ()
+  , rf_polygon       :: forall m. MonadIO m => S.Vector Int16 -> S.Vector Int16
+                                            -> Color -> m ()
+  , rf_thickLine     :: forall m. MonadIO m => V2 CInt -> V2 CInt -> CInt
+                                            -> Color -> m ()
+  , rf_fillTriangle  :: forall m. MonadIO m => V2 CInt -> V2 CInt -> V2 CInt
+                                            -> Color -> m ()
+  , rf_createTexture :: forall m. MonadIO m => Surface -> m Texture
+  , rf_decodeTexture :: forall m. MonadIO m => ByteString -> m Texture
+  }
+
+-- | Build a 'RenderFun' from a real SDL 'Renderer'.
+mkRenderFun :: Renderer -> RenderFun
+mkRenderFun r = MkRenderFun
+  { rf_fillRect      = fillRect r
+  , rf_drawRect      = drawRect r
+  , rf_setDrawColor  = setDrawColor r
+  , rf_copy          = copy r
+  , rf_fillPolygon   = fillPolygon r
+  , rf_polygon       = polygon r
+  , rf_thickLine     = \a b w c -> thickLine r a b w c
+  , rf_fillTriangle  = \a b c col -> fillTriangle r a b c col
+  , rf_createTexture = createTextureFromSurface r
+  , rf_decodeTexture = \bs -> decodeTexture r bs
+  }

--- a/src/Plunder/Render/RenderFun.hs
+++ b/src/Plunder/Render/RenderFun.hs
@@ -11,32 +11,38 @@ module Plunder.Render.RenderFun
 import           Control.Monad.IO.Class (MonadIO)
 import           Data.ByteString        (ByteString)
 import           Data.Int               (Int16)
+import           Data.Word              (Word8)
 import qualified Data.Vector.Storable   as S
 import           Foreign.C.Types        (CInt)
-import           Reflex.SDL2            (Rectangle, Renderer, Surface, Texture,
-                                         V2, copy, createTextureFromSurface,
-                                         drawRect, fillRect)
+import           Reflex.SDL2            (($=), Rectangle, Renderer, Surface,
+                                         Texture, V2, V4, clear, copy,
+                                         createTextureFromSurface, drawRect,
+                                         fillRect, present,
+                                         rendererDrawColor)
 import           SDL.Primitive          (Color, fillPolygon, fillTriangle,
                                          polygon, thickLine)
 import           SDL.Image              (decodeTexture)
 import           Plunder.Render.Color   (setDrawColor)
 
 data RenderFun = MkRenderFun
-  { rf_fillRect      :: forall m. MonadIO m => Maybe (Rectangle CInt) -> m ()
-  , rf_drawRect      :: forall m. MonadIO m => Maybe (Rectangle CInt) -> m ()
-  , rf_setDrawColor  :: forall m. MonadIO m => Color -> m ()
-  , rf_copy          :: forall m. MonadIO m => Texture -> Maybe (Rectangle CInt)
-                                            -> Maybe (Rectangle CInt) -> m ()
-  , rf_fillPolygon   :: forall m. MonadIO m => S.Vector Int16 -> S.Vector Int16
-                                            -> Color -> m ()
-  , rf_polygon       :: forall m. MonadIO m => S.Vector Int16 -> S.Vector Int16
-                                            -> Color -> m ()
-  , rf_thickLine     :: forall m. MonadIO m => V2 CInt -> V2 CInt -> CInt
-                                            -> Color -> m ()
-  , rf_fillTriangle  :: forall m. MonadIO m => V2 CInt -> V2 CInt -> V2 CInt
-                                            -> Color -> m ()
-  , rf_createTexture :: forall m. MonadIO m => Surface -> m Texture
-  , rf_decodeTexture :: forall m. MonadIO m => ByteString -> m Texture
+  { rf_fillRect             :: forall m. MonadIO m => Maybe (Rectangle CInt) -> m ()
+  , rf_drawRect             :: forall m. MonadIO m => Maybe (Rectangle CInt) -> m ()
+  , rf_setDrawColor         :: forall m. MonadIO m => Color -> m ()
+  , rf_copy                 :: forall m. MonadIO m => Texture -> Maybe (Rectangle CInt)
+                                                   -> Maybe (Rectangle CInt) -> m ()
+  , rf_fillPolygon          :: forall m. MonadIO m => S.Vector Int16 -> S.Vector Int16
+                                                   -> Color -> m ()
+  , rf_polygon              :: forall m. MonadIO m => S.Vector Int16 -> S.Vector Int16
+                                                   -> Color -> m ()
+  , rf_thickLine            :: forall m. MonadIO m => V2 CInt -> V2 CInt -> CInt
+                                                   -> Color -> m ()
+  , rf_fillTriangle         :: forall m. MonadIO m => V2 CInt -> V2 CInt -> V2 CInt
+                                                   -> Color -> m ()
+  , rf_createTexture        :: forall m. MonadIO m => Surface -> m Texture
+  , rf_decodeTexture        :: forall m. MonadIO m => ByteString -> m Texture
+  , rf_clear                :: forall m. MonadIO m => m ()
+  , rf_present              :: forall m. MonadIO m => m ()
+  , rf_setRendererDrawColor :: forall m. MonadIO m => V4 Word8 -> m ()
   }
 
 -- | Build a 'RenderFun' from a real SDL 'Renderer'.
@@ -50,6 +56,9 @@ mkRenderFun r = MkRenderFun
   , rf_polygon       = polygon r
   , rf_thickLine     = \a b w c -> thickLine r a b w c
   , rf_fillTriangle  = \a b c col -> fillTriangle r a b c col
-  , rf_createTexture = createTextureFromSurface r
-  , rf_decodeTexture = \bs -> decodeTexture r bs
+  , rf_createTexture        = createTextureFromSurface r
+  , rf_decodeTexture        = \bs -> decodeTexture r bs
+  , rf_clear                = clear r
+  , rf_present              = present r
+  , rf_setRendererDrawColor = \c -> rendererDrawColor r $= c
   }

--- a/src/Plunder/Render/Shop.hs
+++ b/src/Plunder/Render/Shop.hs
@@ -13,10 +13,10 @@ import Foreign.C.Types(CInt)
 import Data.Word(Word8, Word64)
 import Plunder.Shop
 import Plunder.Render.Text
-import Plunder.Render.Color
 import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Reader (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Reflex
 import           Reflex.SDL2
 import           Plunder.Render.Image
@@ -33,12 +33,12 @@ initialState = MkShopState mempty
 
 renderShop :: ReflexSDL2 t m
     => DynamicWriter t [Layer m] m
-    => MonadReader Renderer m
+    => MonadReader RenderFun m
     => Font -> Dynamic t (Maybe ShopContent) -> Dynamic t Word64 -> Dynamic t Bool -> m (Event t ShopAction)
 renderShop font shopContent playerMoney hasRoomForFriend = mdo
-  renderer <- ask
+  rf <- ask
 
-  commitLayer $ renderShopBackground renderer <$> shopContent
+  commitLayer $ renderShopBackground rf <$> shopContent
   shopSurface <- allocateText font shopStyle "Shop"
   void $ image $ shopContent & mapped._Just .~ surfaceToSettings shopSurface (shopPosition 0)
 
@@ -72,7 +72,7 @@ data PurchaseError = ShopClosed
                    | NoItemsSelected
                    | NoRoomForFriend
 
-renderErrorText :: (ReflexSDL2 t m, MonadReader Renderer m) => Font -> Maybe PurchaseError -> Maybe (m ImageSettings)
+renderErrorText :: (ReflexSDL2 t m, MonadReader RenderFun m) => Font -> Maybe PurchaseError -> Maybe (m ImageSettings)
 renderErrorText _ Nothing = Nothing
 renderErrorText small (Just err) = Just $ renderText small shopStyle (shopPosition 5) $ renderError err
 
@@ -109,14 +109,14 @@ purchaseAction playerMoney hasRoom state = \case
               , haulNewMoney = playerMoney - price
             }
 
-renderSlot :: (MonadReader Renderer m, ReflexSDL2 t m, DynamicWriter t [Layer m] m) => Font -> Dynamic t (Maybe ShopContent) -> Dynamic t ShopState -> Int -> (ShopContent -> Maybe ShopItem) -> m (Event t (Word8, (ShopContent -> Maybe ShopItem)))
+renderSlot :: (MonadReader RenderFun m, ReflexSDL2 t m, DynamicWriter t [Layer m] m) => Font -> Dynamic t (Maybe ShopContent) -> Dynamic t ShopState -> Int -> (ShopContent -> Maybe ShopItem) -> m (Event t (Word8, (ShopContent -> Maybe ShopItem)))
 renderSlot font shopContent shopState idx' slot =
   fmap ((idx, slot) <$) $
     image =<< holdDyn Nothing =<< dynView (renderItem font idx . fmap slot <$> shopContent <*> shopState)
   where
      idx = fromIntegral idx'
 
-renderItem :: (ReflexSDL2 t m, MonadReader Renderer m) => Font -> Word8 -> Maybe (Maybe ShopItem) -> ShopState -> m (Maybe ImageSettings)
+renderItem :: (ReflexSDL2 t m, MonadReader RenderFun m) => Font -> Word8 -> Maybe (Maybe ShopItem) -> ShopState -> m (Maybe ImageSettings)
 renderItem font idx content state =
   traverse (renderShopItem font style (idx + 2)) content
 
@@ -141,18 +141,18 @@ shopSelectedStyle :: Style
 shopSelectedStyle = shopStyle & styleColorLens .~ (V4 200 30 30 255)
 
 renderShopBackground :: MonadIO m
-    => Renderer -> Maybe ShopContent -> m ()
-renderShopBackground renderer mshop = do
-  setDrawColor renderer $ V4 200 200 200 255
+    => RenderFun -> Maybe ShopContent -> m ()
+renderShopBackground rf mshop = do
+  rf_setDrawColor rf $ V4 200 200 200 255
   void $ forM_ mshop $ \_content -> do
-    fillRect renderer (Just (Rectangle (P $ V2 20 20) (V2 200 200)))
+    rf_fillRect rf (Just (Rectangle (P $ V2 20 20) (V2 200 200)))
 
 shopPosition :: Word8 -> Point V2 CInt
 shopPosition offset = P $ V2 30 (20 + fromIntegral offset * 20)
 
 renderShopItem ::
   (ReflexSDL2 t m
-  , MonadReader Renderer m) =>
+  , MonadReader RenderFun m) =>
   Font -> Style -> Word8 -> Maybe ShopItem -> m ImageSettings
 renderShopItem font style offset = \case
   Nothing ->

--- a/src/Plunder/Render/Terrain.hs
+++ b/src/Plunder/Render/Terrain.hs
@@ -14,9 +14,10 @@ import           Foreign.C.Types      (CInt)
 import           Plunder.Grid
 import           Plunder.State (GameState, Visibility(Visible, Fog, Unexplored), tileVisibility)
 import           Plunder.Render.Layer
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Reflex
 import           Reflex.SDL2
-import           SDL.Primitive        (fillPolygon, Color)
+import           SDL.Primitive        (Color)
 
 -- | RGBA colour for each terrain type.
 terrainToColor :: Terrain -> Color
@@ -52,29 +53,29 @@ hexPolyPoints axial = (S.fromList xs, S.fromList ys)
 --   the area beyond the map boundary looks like ocean.
 renderTerrain :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => Renderer
+  => RenderFun
   -> Dynamic t Grid
   -> m ()
-renderTerrain renderer boardDyn =
+renderTerrain rf boardDyn =
   commitLayer $ ffor boardDyn $ \board ->
     Foldable.for_ terrainCoords $ \axial ->
       let color = case Map.lookup axial board of
                     Nothing   -> terrainToColor Water
                     Just tile -> terrainToColor (tile ^. tile_terrain)
           (xs, ys) = hexPolyPoints axial
-      in fillPolygon renderer xs ys color
+      in rf_fillPolygon rf xs ys color
 
 -- | Render a fog-of-war overlay on top of terrain and sprites.
 --   Tiles close to a player are fully visible, farther tiles get a
 --   semi-transparent or fully opaque dark overlay.
 renderFogOverlay :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
-  => Renderer -> Dynamic t GameState -> m ()
-renderFogOverlay renderer stateDyn =
+  => RenderFun -> Dynamic t GameState -> m ()
+renderFogOverlay rf stateDyn =
   commitLayer $ ffor stateDyn $ \gs ->
     Foldable.for_ terrainCoords $ \axial ->
       let (xs, ys) = hexPolyPoints axial
       in case tileVisibility gs axial of
         Visible -> pure ()
-        Fog     -> fillPolygon renderer xs ys (V4 0 0 0 128)
-        Unexplored -> fillPolygon renderer xs ys (V4 0 0 0 255)
+        Fog     -> rf_fillPolygon rf xs ys (V4 0 0 0 128)
+        Unexplored -> rf_fillPolygon rf xs ys (V4 0 0 0 255)

--- a/src/Plunder/Render/Text.hs
+++ b/src/Plunder/Render/Text.hs
@@ -16,6 +16,7 @@ module Plunder.Render.Text(
 import Plunder.Lens
 import           Control.Lens
 import           Control.Monad.Reader   (MonadReader (..))
+import           Plunder.Render.RenderFun (RenderFun(..))
 import           Data.Text              (Text)
 import           Foreign.C.Types        (CInt)
 import           Reflex.SDL2
@@ -44,12 +45,12 @@ data TextSurface = MkTextSurface
 
 -- | Create a 'TextSurface' from a font, style, and text string.
 --   This only allocates the SDL texture; it does not draw anything on screen.
-allocateText :: (ReflexSDL2 t m, MonadReader Renderer m) => Font -> Style -> Text -> m TextSurface
+allocateText :: (ReflexSDL2 t m, MonadReader RenderFun m) => Font -> Style -> Text -> m TextSurface
 allocateText font style text = do
-      r    <- ask
+      MkRenderFun{rf_createTexture} <- ask
       textSurface <- Font.solid font color text
       fontHexSize <- fmap fromIntegral . uncurry V2 <$> Font.size font text
-      textTexture <- createTextureFromSurface r textSurface -- I think textures are cleaned automatically
+      textTexture <- rf_createTexture textSurface
       freeSurface textSurface
       pure $ MkTextSurface
           { textSurfaceFontHexSize = fontHexSize
@@ -87,7 +88,7 @@ textSurfaceSize = textSurfaceFontHexSize
 --   For a convenience wrapper that renders /and/ displays in one step, see
 --   @panelText@ in "Plunder.Render.ContextPanel".
 renderText :: ReflexSDL2 t m
-  => MonadReader Renderer m
+  => MonadReader RenderFun m
   => Font -> Style -> Point V2 CInt -> Text -> m ImageSettings
 renderText font style position text =
       flip surfaceToSettings position <$> allocateText font style text


### PR DESCRIPTION
## Summary
- Introduce `Plunder.Render.RenderFun` module with a `RenderFun` record of partially-applied SDL drawing functions and `mkRenderFun` constructor
- Replace all `MonadReader Renderer m` constraints with `MonadReader RenderFun m` across 15 modules
- `Plunder.hs` passes `Renderer` explicitly only for `clear`/`present`; the reader environment carries `RenderFun`
- Enables future mock-based render testing without requiring a live SDL window

## Test plan
- [x] `nix-build default.nix` passes (typechecks, no new warnings, all existing tests pass)
- [x] No `MonadReader Renderer` constraints remain outside `Plunder.hs`
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)