### PR TITLE
Add camera panning with arrow keys

### DIFF
--- a/src/Plunder/Grid.hs
+++ b/src/Plunder/Grid.hs
@@ -11,6 +11,8 @@ module Plunder.Grid
   , roundAxial
   , axialToPixel
   , pixelToAxial
+  , axialToPixelCam
+  , pixelToAxialCam
   , hexSize
   , neigbours
   , tile_axial
@@ -157,6 +159,14 @@ axialToPixel coord = (P $ V2 x y)
         )
   y :: CInt
   y = floor $ fromIntegral hexSize * (3.0 / two * (fromIntegral $ coord ^. _r))
+
+-- | Convert axial coordinate to pixel position with a camera offset applied.
+axialToPixelCam :: V2 CInt -> Axial -> Point V2 CInt
+axialToPixelCam cam coord = axialToPixel coord + P cam
+
+-- | Convert pixel position to axial coordinate, undoing a camera offset first.
+pixelToAxialCam :: V2 CInt -> Point V2 CInt -> Axial
+pixelToAxialCam cam pixel = pixelToAxial (pixel - P cam)
 
 -- https://www.redblobgames.com/grids/hexagons/#pixel-to-hex
 pixelToAxial :: Point V2 CInt -> Axial

--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -20,6 +20,7 @@ import           Plunder.State
 import           System.Random
 import Plunder.Mouse
 import Plunder.Shop
+import Plunder.Grid (hexSize)
 import Plunder.Render.Font(defaultFont, bigFont)
 import Plunder.Render.ContextPanel
 import Plunder.Render.Inventory
@@ -72,7 +73,7 @@ makeRandomNT =
   newStdGen <&> \stdgen -> MkRandTNT (\inner -> fst <$> runRandT inner stdgen)
 
 mkGameState :: forall t m . ReflexSDL2 t m => GameState -> Dynamic t Bool -> Event t ShopAction -> Event t ShopItem -> m (Dynamic t GameState, Dynamic t Word8, Dynamic t (V2 CInt), () -> IO ())
-mkGameState initGS helpOpen shopActions inventoryActions = do
+mkGameState initGS helpOpen shopActions inventoryActions = mdo
 
   -- figured these out with getAnySDLEvent and see which needed to redraw
   windowExposedEvt <- getWindowExposedEvent
@@ -101,8 +102,8 @@ mkGameState initGS helpOpen shopActions inventoryActions = do
       boardLeftClicks  = attachWithMaybe onBoard (current winSizeDyn) leftClickEvts
       boardRightClicks :: Event t MouseButtonEventData
       boardRightClicks = attachWithMaybe onBoard (current winSizeDyn) rightClickEvts
-      leftClickAxial = calcMouseClickAxial <$> boardLeftClicks
-      rightClickAxialEvt = calcMouseClickAxial <$> boardRightClicks
+      leftClickAxial = attachWith calcMouseClickAxialCam (view game_camera <$> current state) boardLeftClicks
+      rightClickAxialEvt = attachWith calcMouseClickAxialCam (view game_camera <$> current state) boardRightClicks
       toggleInvEvt :: Event t ()
       toggleInvEvt = () <$ ffilter (\kd ->
           has _Pressed (keyboardEventKeyMotion kd) &&
@@ -115,6 +116,20 @@ mkGameState initGS helpOpen shopActions inventoryActions = do
           not (keyboardEventRepeat kd) &&
           keysymKeycode (keyboardEventKeysym kd) == KeycodeSpace
         ) keyboardEvt
+      camStep :: CInt
+      camStep = fromIntegral hexSize
+      arrowKeyEvt :: Keycode -> V2 CInt -> Event t (V2 CInt)
+      arrowKeyEvt kc delta = delta <$ ffilter (\kd ->
+          has _Pressed (keyboardEventKeyMotion kd) &&
+          keysymKeycode (keyboardEventKeysym kd) == kc
+        ) keyboardEvt
+      cameraEvt :: Event t (V2 CInt)
+      cameraEvt = leftmost
+        [ arrowKeyEvt KeycodeUp    (V2 0 (-camStep))
+        , arrowKeyEvt KeycodeDown  (V2 0 camStep)
+        , arrowKeyEvt KeycodeLeft  (V2 (-camStep) 0)
+        , arrowKeyEvt KeycodeRight (V2 camStep 0)
+        ]
       helpClosed = not <$> current helpOpen
       events = leftmost [ gate helpClosed $ ShopUpdates <$> shopActions
                         , gate helpClosed $ UseItem <$> inventoryActions
@@ -126,6 +141,7 @@ mkGameState initGS helpOpen shopActions inventoryActions = do
                         , ResetGame <$ resetEvt
                         , gate helpClosed $ EndTurn <$ endTurnEvt
                         , gate helpClosed $ EndTurn <$ spaceEvt
+                        , CameraMove <$> cameraEvt
                         ]
   performEvent_ $ ffor events $ liftIO . print
 

--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -125,10 +125,10 @@ mkGameState initGS helpOpen shopActions inventoryActions = mdo
         ) keyboardEvt
       cameraEvt :: Event t (V2 CInt)
       cameraEvt = leftmost
-        [ arrowKeyEvt KeycodeUp    (V2 0 (-camStep))
-        , arrowKeyEvt KeycodeDown  (V2 0 camStep)
-        , arrowKeyEvt KeycodeLeft  (V2 (-camStep) 0)
-        , arrowKeyEvt KeycodeRight (V2 camStep 0)
+        [ arrowKeyEvt KeycodeUp    (V2 0 camStep)
+        , arrowKeyEvt KeycodeDown  (V2 0 (-camStep))
+        , arrowKeyEvt KeycodeLeft  (V2 camStep 0)
+        , arrowKeyEvt KeycodeRight (V2 (-camStep) 0)
         ]
       helpClosed = not <$> current helpOpen
       events = leftmost [ gate helpClosed $ ShopUpdates <$> shopActions

--- a/src/Plunder/Mouse.hs
+++ b/src/Plunder/Mouse.hs
@@ -11,6 +11,7 @@ module Plunder.Mouse
   , mouseMotion
   , _Pressed
   , calcMouseClickAxial
+  , calcMouseClickAxialCam
   , isClickInPanel
   ) where
 
@@ -43,6 +44,10 @@ _Pressed = _Ctor @"Pressed"
 
 calcMouseClickAxial :: MouseButtonEventData -> Axial
 calcMouseClickAxial = pixelToAxial . fmap fromIntegral . view mousePositions
+
+-- | Convert a mouse click to axial coordinates, accounting for camera offset.
+calcMouseClickAxialCam :: V2 CInt -> MouseButtonEventData -> Axial
+calcMouseClickAxialCam cam = pixelToAxialCam cam . fmap fromIntegral . view mousePositions
 
 -- | Returns 'True' when the click lands in the bottom panel area
 -- (Y coordinate >= windowHeight - panelH).

--- a/src/Plunder/Render.hs
+++ b/src/Plunder/Render.hs
@@ -14,7 +14,6 @@ import           Plunder.Render.RenderFun (RenderFun(..))
 import           Foreign.C.Types      (CInt)
 import qualified Data.Map.Strict      as Map
 import qualified Data.Text            as T
-import           Data.Bool
 import           Data.Foldable
 import           Data.Monoid
 import           Plunder.Grid
@@ -36,49 +35,52 @@ renderState :: ReflexSDL2 t m
 renderState font state = do
   rf <- ask
 
+  let cameraDyn = view game_camera <$> state
+
   -- Terrain fill is the very first (lowest) layer: coloured hexagons for
   -- every coordinate in range, with Water used for anything outside the grid.
-  renderTerrain rf (view game_board <$> state)
+  renderTerrain rf cameraDyn (view game_board <$> state)
 
-  vikingF <- renderImage <$> loadViking
-  enemyF <- renderImage <$> loadEnemy
-  loadBloodF <- renderImage <$> loadBlood
-  houseF <- renderImage <$> loadHouse
-  burnedHouseF <- renderImage <$> burndedHouse
-  loadShopF <- renderImage <$> loadShop
+  vikingTex <- loadViking
+  enemyTex <- loadEnemy
+  bloodTex <- loadBlood
+  houseTex <- loadHouse
+  burnedHouseTex <- burndedHouse
+  shopTex <- loadShop
 
-  axeF <- fmap renderWeapon . renderImage <$> loadAxe
-  swordF <- fmap renderWeapon . renderImage <$> loadSword
-  loadF <- fmap renderWeapon . renderImage <$> loadBow
+  axeTex <- loadAxe
+  swordTex <- loadSword
+  bowTex <- loadBow
 
   let renderOrduning =
-            [ applyImage loadBloodF $ tile_background . _Just . _Blood
-            , applyImage burnedHouseF $ tile_background . _Just . _BurnedHouse
-            , applyImage enemyF $ tile_content . _Just . _Enemy
-            , applyImage vikingF $ tile_content . _Just . _Player
-            , applyImage houseF $ tile_content . _Just . _House
-            , applyImage loadShopF $ tile_content . _Just . _Shop
-            , applyImage swordF $ tile_content . _Just . tc_unit . unit_weapon . _Just . _Sword
-            , applyImage loadF $ tile_content . _Just . tc_unit . unit_weapon . _Just . _Bow
-            , applyImage axeF $ tile_content . _Just . tc_unit . unit_weapon . _Just . _Axe
+            [ applyImageCam cameraDyn (renderImageCam' bloodTex) $ tile_background . _Just . _Blood
+            , applyImageCam cameraDyn (renderImageCam' burnedHouseTex) $ tile_background . _Just . _BurnedHouse
+            , applyImageCam cameraDyn (renderImageCam' enemyTex) $ tile_content . _Just . _Enemy
+            , applyImageCam cameraDyn (renderImageCam' vikingTex) $ tile_content . _Just . _Player
+            , applyImageCam cameraDyn (renderImageCam' houseTex) $ tile_content . _Just . _House
+            , applyImageCam cameraDyn (renderImageCam' shopTex) $ tile_content . _Just . _Shop
+            , applyImageCam cameraDyn (\cam -> renderWeapon . renderImageCam cam swordTex) $ tile_content . _Just . tc_unit . unit_weapon . _Just . _Sword
+            , applyImageCam cameraDyn (\cam -> renderWeapon . renderImageCam cam bowTex) $ tile_content . _Just . tc_unit . unit_weapon . _Just . _Bow
+            , applyImageCam cameraDyn (\cam -> renderWeapon . renderImageCam cam axeTex) $ tile_content . _Just . tc_unit . unit_weapon . _Just . _Axe
             ]
 
   void $ listWithKey (view game_board <$> state) $ \axial _ -> do
-    hexagon $ renderHex font axial
+    hexagonDyn $ renderHexCam <$> cameraDyn <*> pure font <*> pure axial
 
   -- simple list doesn't cache on key change
   void $ listWithKey (view game_board <$> state) $ \axial tileDyn -> do
     traverse_ (\fun -> fun axial tileDyn) renderOrduning
-    healthBar tileDyn
+    healthBar cameraDyn tileDyn
 
   -- Selection outline drawn last so it sits on top of unit sprites
   void $ holdView (pure ())
-       $ hexagon . renderSelected font <$> mapMaybe (view game_selected) (updated state)
+       $ (\axial -> hexagonDyn $ renderSelected <$> cameraDyn <*> pure font <*> pure axial)
+         <$> mapMaybe (view game_selected) (updated state)
 
   -- Draw planned-move arrows on top of units
-  commitLayer $ ffor (view game_planned_moves <$> state) $ \plans ->
+  commitLayer $ ffor2 cameraDyn (view game_planned_moves <$> state) $ \cam plans ->
     for_ (Map.toList plans) $ \(src, path) ->
-      drawPathArrows rf axialToPixel src path (V4 255 165 0 255)
+      drawPathArrows rf (axialToPixelCam cam) src path (V4 255 165 0 255)
 
   -- Fog of war overlay (covers terrain, sprites and arrows, but not HUD)
   renderFogOverlay rf state
@@ -105,32 +107,40 @@ renderState font state = do
                   . tile_coordinate of
           Nothing        -> pure Nothing
           Just playerPos ->
-            let P (V2 px py) = axialToPixel playerPos
+            let P (V2 px py) = axialToPixelCam (gs ^. game_camera) playerPos
             in Just <$> renderText font defaultStyle (P $ V2 px (py - 25))
                           (describePurchase haul))
   void $ image =<< holdDyn Nothing purchaseLabelEvt
 
+-- | Helper to flip argument order for renderImageCam.
+renderImageCam' :: Texture -> V2 CInt -> Axial -> ImageSettings
+renderImageCam' tex cam = renderImageCam cam tex
 
-applyImage ::
+-- | Camera-aware version of applyImage. The image position reacts to camera changes.
+applyImageCam ::
   DynamicWriter t [Performable m ()] m
   => MonadReader RenderFun m
   => ReflexSDL2 t m
-  => (Axial -> ImageSettings)
+  => Dynamic t (V2 CInt)
+  -> (V2 CInt -> Axial -> ImageSettings)
   -> Getting Any Tile a -- ^ condition on the tile for rendering
   -> Axial
   -> Dynamic t Tile
   ->  m ()
-applyImage textureF hashPath axial tileDyn =
-  void $ image $ fmap textureF <$> someSettings
+applyImageCam cameraDyn textureF hashPath axial tileDyn =
+  void $ image someSettings
   where
-    someSettings = bool Nothing (Just axial)
-                       . has hashPath <$> tileDyn
+    someSettings = (\cam tile ->
+        if has hashPath tile
+          then Just (textureF cam axial)
+          else Nothing
+      ) <$> cameraDyn <*> tileDyn
 
-renderSelected :: Font -> Axial -> HexagonSettings
-renderSelected font = (hexagon_color .~ V4 255 255 0 255)
+renderSelected :: V2 CInt -> Font -> Axial -> HexagonSettings
+renderSelected cam font = (hexagon_color .~ V4 255 255 0 255)
                . (hexagon_is_filled .~ False)
                . (hexagon_label .~ Nothing)
-               . renderHex font
+               . renderHexCam cam font
 
 describePurchase :: Haul -> T.Text
 describePurchase haul =

--- a/src/Plunder/Render/Health.hs
+++ b/src/Plunder/Render/Health.hs
@@ -18,10 +18,10 @@ import SDL.Primitive(Color)
 healthBar :: DynamicWriter t [Layer m] m
         => ReflexSDL2 t m
         => MonadReader RenderFun m
-        => Dynamic t Tile -> m ()
-healthBar tileDyn = do
+        => Dynamic t (V2 CInt) -> Dynamic t Tile -> m ()
+healthBar cameraDyn tileDyn = do
   rf <- ask
-  commitLayer $ healthBar' rf <$> tileDyn
+  commitLayer $ healthBar' rf <$> cameraDyn <*> tileDyn
 
 barHeight :: Num a => a
 barHeight = 6
@@ -42,8 +42,8 @@ borderColor :: Color
 borderColor = V4 0 0 0 255
 
 healthBar' :: MonadIO m
-        => RenderFun -> Tile -> m ()
-healthBar' rf tile = unless isDead $ do
+        => RenderFun -> V2 CInt -> Tile -> m ()
+healthBar' rf cam tile = unless isDead $ do
     -- dark background (full max-health width)
     rf_setDrawColor rf bgColor
     rf_fillRect rf $ Just bgRect
@@ -60,7 +60,7 @@ healthBar' rf tile = unless isDead $ do
         pure $ Combat.isDead hp'
 
       origin :: Point V2 CInt
-      origin = axialToPixel coord - P (V2 (pixelsPerHealth * fromIntegral maxHealth `div` 2) 20)
+      origin = axialToPixelCam cam coord - P (V2 (pixelsPerHealth * fromIntegral maxHealth `div` 2) 20)
 
       coord :: Axial
       coord = tile ^. tile_coordinate

--- a/src/Plunder/Render/Hexagon.hs
+++ b/src/Plunder/Render/Hexagon.hs
@@ -8,6 +8,7 @@
 
 module Plunder.Render.Hexagon
   ( hexagon
+  , hexagonDyn
   , HexagonSettings
   , defHex
   , hexagon_position
@@ -15,6 +16,7 @@ module Plunder.Render.Hexagon
   , hexagon_is_filled
   , hexagon_label
   , renderHex
+  , renderHexCam
   )
 where
 
@@ -123,9 +125,25 @@ hexagon settings = do
       image $ pure $ Just imageSettings
   pure ()
 
+-- | Like 'hexagon' but takes dynamic settings, so the outline moves with the camera.
+hexagonDyn
+  :: ReflexSDL2 t m
+  => MonadReader RenderFun m
+  => DynamicWriter t [Layer m] m => Dynamic t HexagonSettings -> m ()
+hexagonDyn settingsDyn = do
+  MkRenderFun{rf_fillPolygon, rf_polygon} <- ask
+  commitLayer $ ffor settingsDyn $ \settings -> do
+    let polgyonF = if settings ^. hexagon_is_filled then rf_fillPolygon else rf_polygon
+        (xPoints, yPoints) = calcPoints settings
+    polgyonF xPoints yPoints $ settings ^. hexagon_color
+
 -- https://www.redblobgames.com/grids/hexagons/#hex-to-pixel
 renderHex :: Font -> Axial -> HexagonSettings
-renderHex font coord = hexagon_position .~ (axialToPixel coord)
+renderHex = renderHexCam (V2 0 0)
+
+-- | Like 'renderHex' but with a camera pixel offset applied.
+renderHexCam :: V2 CInt -> Font -> Axial -> HexagonSettings
+renderHexCam cam font coord = hexagon_position .~ (axialToPixelCam cam coord)
                 $ hexagon_label ?~ (Text.pack $ printf "%i,%i" (coord ^. _q) $ (coord ^. _r))
                 $ hexagon_font .~ font
                 $ defHex

--- a/src/Plunder/Render/Image.hs
+++ b/src/Plunder/Render/Image.hs
@@ -8,6 +8,7 @@ module Plunder.Render.Image(
             , image
             , imageEvt
             , renderImage
+            , renderImageCam
             , rectangle_pos
             , rectangle_size
             , image_position
@@ -193,8 +194,12 @@ renderWeapon =
   (image_position . rectangle_size . _y -~ 20)
 
 renderImage :: Texture -> Axial -> ImageSettings
-renderImage text coord = ImageSettings {
-        _image_position  = Rectangle (axialToPixel coord) (V2 50 50)
+renderImage = renderImageCam (V2 0 0)
+
+-- | Like 'renderImage' but with a camera pixel offset applied.
+renderImageCam :: V2 CInt -> Texture -> Axial -> ImageSettings
+renderImageCam cam text coord = ImageSettings {
+        _image_position  = Rectangle (axialToPixelCam cam coord) (V2 50 50)
       , _image_content  = text
       }
 

--- a/src/Plunder/Render/Terrain.hs
+++ b/src/Plunder/Render/Terrain.hs
@@ -12,7 +12,7 @@ import           Control.Lens
 import           Data.Int             (Int16)
 import           Foreign.C.Types      (CInt)
 import           Plunder.Grid
-import           Plunder.State (GameState, Visibility(Visible, Fog, Unexplored), tileVisibility)
+import           Plunder.State (GameState, Visibility(Visible, Fog, Unexplored), tileVisibility, game_camera)
 import           Plunder.Render.Layer
 import           Plunder.Render.RenderFun (RenderFun(..))
 import           Reflex
@@ -31,11 +31,11 @@ terrainCoords :: [Axial]
 terrainCoords = [MkAxial q r | q <- [-1 .. 7], r <- [-1 .. 7]]
 
 -- | Compute the six polygon corners of a pointy-top hexagon at the given
---   axial coordinate.
-hexPolyPoints :: Axial -> (S.Vector Int16, S.Vector Int16)
-hexPolyPoints axial = (S.fromList xs, S.fromList ys)
+--   axial coordinate, with a camera pixel offset applied.
+hexPolyPoints :: V2 CInt -> Axial -> (S.Vector Int16, S.Vector Int16)
+hexPolyPoints cam axial = (S.fromList xs, S.fromList ys)
   where
-    P (V2 cx cy) = axialToPixel axial
+    P (V2 cx cy) = axialToPixelCam cam axial
     -- Pointy-top hexagon corners at 330°, 30°, 90°, 150°, 210°, 270°.
     cornerDegrees :: [Double]
     cornerDegrees = [330, 30, 90, 150, 210, 270]
@@ -54,15 +54,16 @@ hexPolyPoints axial = (S.fromList xs, S.fromList ys)
 renderTerrain :: ReflexSDL2 t m
   => DynamicWriter t [Layer m] m
   => RenderFun
+  -> Dynamic t (V2 CInt)
   -> Dynamic t Grid
   -> m ()
-renderTerrain rf boardDyn =
-  commitLayer $ ffor boardDyn $ \board ->
+renderTerrain rf cameraDyn boardDyn =
+  commitLayer $ ffor2 cameraDyn boardDyn $ \cam board ->
     Foldable.for_ terrainCoords $ \axial ->
       let color = case Map.lookup axial board of
                     Nothing   -> terrainToColor Water
                     Just tile -> terrainToColor (tile ^. tile_terrain)
-          (xs, ys) = hexPolyPoints axial
+          (xs, ys) = hexPolyPoints cam axial
       in rf_fillPolygon rf xs ys color
 
 -- | Render a fog-of-war overlay on top of terrain and sprites.
@@ -73,8 +74,9 @@ renderFogOverlay :: ReflexSDL2 t m
   => RenderFun -> Dynamic t GameState -> m ()
 renderFogOverlay rf stateDyn =
   commitLayer $ ffor stateDyn $ \gs ->
-    Foldable.for_ terrainCoords $ \axial ->
-      let (xs, ys) = hexPolyPoints axial
+    let cam = gs ^. game_camera
+    in Foldable.for_ terrainCoords $ \axial ->
+      let (xs, ys) = hexPolyPoints cam axial
       in case tileVisibility gs axial of
         Visible -> pure ()
         Fog     -> rf_fillPolygon rf xs ys (V4 0 0 0 128)

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -21,6 +21,7 @@ module Plunder.State(GameState(..)
             , game_planned_moves
             , game_pending_purchase
             , game_explored
+            , game_camera
             , inventory_money
             , inventroy_item
             , PlayerInventory(..)
@@ -55,7 +56,9 @@ import           Data.Functor.Compose
 import           Data.Monoid
 import           Data.Word
 import           Debug.Trace
+import           Foreign.C.Types                 (CInt)
 import           GHC.Generics                    (Generic)
+import           SDL.Vect                        (V2(..))
 import           Plunder.Grid
 import           Plunder.Pathfinding
 import           System.Random
@@ -112,6 +115,7 @@ data GameState = MkGameState
   , _game_planned_moves     :: Map Axial [Axial]  -- ^ from -> path (excluding src): queued player moves
   , _game_pending_purchase  :: Maybe Haul        -- ^ purchase queued, applied on EndTurn
   , _game_explored          :: Set Axial         -- ^ tiles that have been within visibility range
+  , _game_camera            :: V2 CInt           -- ^ pixel offset for camera panning
   } deriving (Show)
 makeLenses ''GameState
 makeLenses ''PlayerInventory
@@ -199,6 +203,7 @@ levelToGameState lvl =
         , _game_planned_moves    = Map.empty
         , _game_pending_purchase = Nothing
         , _game_explored         = Set.empty
+        , _game_camera           = V2 0 0
         }
   in gs0 & game_explored .~ computeNewlyExplored gs0
   where
@@ -366,6 +371,7 @@ data UpdateEvts = LeftClick Axial
                 | ResetGame -- ^ fired after the death/victory banner expires
                 | EndTurn   -- ^ execute all planned moves
                 | UseItem ShopItem
+                | CameraMove (V2 CInt) -- ^ pan the camera by a pixel delta
                 deriving (Show, Eq)
 
 applyAttack :: MonadRandom m => MonadState GameState m =>  Action -> m (Maybe Result)
@@ -424,6 +430,7 @@ executePlannedMove gs src dst = do
 updateLogic :: MonadRandom m => MonadState GameState m => GameState -> UpdateEvts -> m ()
 updateLogic resetTo = \case
   Redraw -> pure ()
+  CameraMove delta -> game_camera %= (+ delta)
   ToggleInventory -> modifying game_inventory_open not
   ShopUpdates actions -> applyShopUpdates actions
   LeftClick axial -> assign game_selected (Just axial)

--- a/test/Test/StateSpec.hs
+++ b/test/Test/StateSpec.hs
@@ -786,6 +786,33 @@ spec = do
     contextTerrain ContextNone
       `shouldBe` Nothing
 
+ describe "Camera panning" $ do
+  it "camera starts at V2 0 0" $
+    initialState ^. game_camera `shouldBe` V2 0 0
+
+  it "CameraMove adds the delta to the camera offset" $
+    runEvt (CameraMove (V2 80 0)) initialState ^. game_camera
+      `shouldBe` V2 80 0
+
+  it "multiple CameraMove events accumulate" $ do
+    let result = runEvt (CameraMove (V2 0 (-80)))
+               $ runEvt (CameraMove (V2 80 0)) initialState
+    result ^. game_camera `shouldBe` V2 80 (-80)
+
+  it "CameraMove does not affect game_board" $ do
+    let result = runEvt (CameraMove (V2 80 80)) initialState
+    result ^. game_board `shouldBe` initialState ^. game_board
+
+  it "CameraMove does not affect game_selected" $ do
+    let selected = initialState & game_selected .~ Just (MkAxial 2 3)
+        result = runEvt (CameraMove (V2 80 0)) selected
+    result ^. game_selected `shouldBe` Just (MkAxial 2 3)
+
+  it "ResetGame resets camera to V2 0 0" $ do
+    let panned = initialState & game_camera .~ V2 160 (-80)
+        result = runEvt ResetGame panned
+    result ^. game_camera `shouldBe` V2 0 0
+
  describe "Off-grid and shop distance" $ do
   it "selecting an off-grid tile returns ContextNone" $ do
     let gs = initialState & game_selected .~ Just (MkAxial 99 99)


### PR DESCRIPTION
## Summary
- Arrow keys pan the camera by one tile width (80px) per press
- All rendering (terrain, hexagons, sprites, health bars, fog, arrows, purchase labels) shifts with the camera
- Mouse click detection accounts for camera offset so clicks still map to the correct tile
- Camera offset stored in `GameState` as `game_camera :: V2 CInt`

## Changes
- **Grid.hs**: Added `axialToPixelCam` / `pixelToAxialCam` helpers
- **State.hs**: Added `game_camera` field and `CameraMove` event
- **Guest.hs**: Arrow key handling mapped to `CameraMove` events (uses `mdo` for recursive binding)
- **Mouse.hs**: Added `calcMouseClickAxialCam` for camera-aware click conversion
- **Render.hs**: Thread camera through all rendering; images use `applyImageCam` with dynamic camera
- **Render/Terrain.hs**, **Render/Hexagon.hs**, **Render/Image.hs**, **Render/Health.hs**: Accept camera offset

## Test plan
- [x] All 145 unit tests pass
- [x] Builds with no new warnings
- [ ] Manual testing: arrow keys pan the view, clicks still target the correct hex

🤖 Generated with [Claude Code](https://claude.com/claude-code)