### PR TITLE
Return Dynamic t GameState from app/guest for test inspection

### DIFF
--- a/src/Plunder.hs
+++ b/src/Plunder.hs
@@ -19,17 +19,19 @@ import           Plunder.Render.RenderFun (RenderFun(..), mkRenderFun)
 import           Plunder.State (GameState, levelToGameState)
 import           qualified SDL.Font as Font
 
-app :: (ReflexSDL2 t m, MonadReader RenderFun m) => GameState -> m ()
+app :: (ReflexSDL2 t m, MonadReader RenderFun m) => GameState -> m (Dynamic t GameState)
 app initGS = do
-  (_, dynLayers) <- runDynamicWriterT $ do
-    guest initGS
+  (gameState, dynLayers) <- runDynamicWriterT $ do
+    gs <- guest initGS
     onQuit
+    pure gs
   MkRenderFun{rf_clear, rf_present, rf_setRendererDrawColor} <- ask
   performEvent_ $ ffor (updated dynLayers) $ \layers -> do
     rf_setRendererDrawColor (V4 0 0 0 255)
     rf_clear
     sequence_ layers
     rf_present
+  pure gameState
 
 main :: IO ()
 main = do
@@ -61,7 +63,7 @@ main = do
   rendererDrawBlendMode r $= BlendAlphaBlend
   -- Host the network with an example of how to embed your own effects.
   -- In this case it's a simple reader.
-  host $ runReaderT (app initGS) (mkRenderFun r)
+  host $ void $ runReaderT (app initGS) (mkRenderFun r)
   destroyRenderer r
   destroyWindow window
   quit

--- a/src/Plunder/Guest.hs
+++ b/src/Plunder/Guest.hs
@@ -33,7 +33,7 @@ import Control.Concurrent (forkIO, threadDelay)
 guest
   :: forall t m
    . ReflexSDL2 t m
-  => DynamicWriter t [Layer m] m => MonadReader RenderFun m => GameState -> m ()
+  => DynamicWriter t [Layer m] m => MonadReader RenderFun m => GameState -> m (Dynamic t GameState)
 guest initGS = mdo
   -- Print some stuff after the network is built.
   evPB           <- getPostBuild
@@ -64,7 +64,7 @@ guest initGS = mdo
         Just $ surfaceToSettings endTurnSurface (P $ V2 (w - btnW - 10) (h - panelHeight - btnH - 10))
   endTurnClicks <- image endTurnImgDyn
   performEvent_ $ ffor endTurnClicks $ \_ -> liftIO (fireEndTurn ())
-  pure ()
+  pure gameState
 
 
 

--- a/test/Test/IntegrationSpec.hs
+++ b/test/Test/IntegrationSpec.hs
@@ -3,9 +3,13 @@
 
 module Test.IntegrationSpec (spec) where
 
+import           Control.Lens           (view)
+import           Control.Monad          (void)
 import           Data.IORef
 import           Data.Word              (Word8)
-import           Reflex.SDL2            (V4 (..), WindowExposedEventData (..))
+import           Reflex                 (ffor, performEvent_, updated)
+import           Reflex.SDL2            (V4 (..), WindowExposedEventData (..),
+                                         liftIO)
 import           SDL                    (InputMotion (..), KeyModifier (..),
                                          Keysym (..), KeyboardEventData (..))
 import           SDL.Input.Keyboard.Codes (pattern KeycodeReturn,
@@ -13,7 +17,9 @@ import           SDL.Input.Keyboard.Codes (pattern KeycodeReturn,
 import           Test.Hspec
 
 import           Plunder                (app)
-import           Plunder.State          (initialState)
+import           Plunder.State          (GamePhase (..), game_inventory_open,
+                                         game_phase, game_selected, game_shop,
+                                         initialState)
 import           Test.IntegrationExpected
 import           Test.TestHost
 
@@ -72,7 +78,7 @@ spec :: Spec
 spec = do
   describe "initial render after WindowExposed" $
     beforeAll (withTestEnv $ \env -> do
-      (handle, ref) <- bootApp env (app initialState)
+      (handle, ref) <- bootApp env (void $ app initialState)
       fireWindowExposed handle (WindowExposedEventData (teWindow env))
       pure (handle, ref, env)
     ) $ do
@@ -114,26 +120,36 @@ spec = do
 
   describe "after pressing Enter to dismiss help" $
     beforeAll (withTestEnv $ \env -> do
-      (handle, ref) <- bootApp env (app initialState)
+      stateRef <- newIORef initialState
+      (handle, ref) <- bootApp env $ do
+        dynGS <- app initialState
+        performEvent_ $ ffor (updated dynGS) $ liftIO . writeIORef stateRef
       fireWindowExposed handle (WindowExposedEventData (teWindow env))
       initialCalls <- readIORef ref
       -- Clear the log then press Enter to dismiss the help overlay
       writeIORef ref []
       fireKeyboard handle enterKeyPress
       afterCalls <- readIORef ref
-      pure (initialCalls, afterCalls)
+      gs <- readIORef stateRef
+      pure (initialCalls, afterCalls, gs)
     ) $ do
 
-      it "triggers a render cycle" $ \(_, afterCalls) -> do
+      it "triggers a render cycle" $ \(_, afterCalls, _) -> do
         filter isClear afterCalls `shouldSatisfy` (not . null)
         filter isPresent afterCalls `shouldSatisfy` (not . null)
 
-      it "no longer renders the help overlay border" $ \(initialCalls, afterCalls) -> do
+      it "no longer renders the help overlay border" $ \(initialCalls, afterCalls, _) -> do
         let initialDrawRects = length $ filter isDrawRect initialCalls
             afterDrawRects   = length $ filter isDrawRect afterCalls
         afterDrawRects `shouldSatisfy` (< initialDrawRects)
 
-      it "renders fewer copies without help text" $ \(initialCalls, afterCalls) -> do
+      it "renders fewer copies without help text" $ \(initialCalls, afterCalls, _) -> do
         let initialCopies = length $ filter isCopy initialCalls
             afterCopies   = length $ filter isCopy afterCalls
         afterCopies `shouldSatisfy` (< initialCopies)
+
+      it "game state is still Playing with no selection" $ \(_, _, gs) -> do
+        view game_phase gs `shouldBe` Playing
+        view game_selected gs `shouldBe` Nothing
+        view game_shop gs `shouldBe` Nothing
+        view game_inventory_open gs `shouldBe` False


### PR DESCRIPTION
## Summary
- `guest` and `app` now return `Dynamic t GameState` instead of `()`
- `main` uses `void` to discard the return value (production behaviour unchanged)
- Integration test captures the game state via IORef after pressing Enter and asserts: game phase is `Playing`, no selection, no shop, inventory closed

This lets future integration tests inspect the actual game state after any event tick, rather than inferring it from render call patterns.

## Test plan
- [x] 162 tests pass (including new game-state assertion)
- [x] No new warnings
- [x] Library and executable build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)