### PR TITLE
add enemy AI with line-of-sight and pursuit

### DIFF
--- a/game13.cabal
+++ b/game13.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
       Plunder
+      Plunder.AI
       Plunder.Combat
       Plunder.Grid
       Plunder.Guest
@@ -159,6 +160,7 @@ test-suite unit
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.AISpec
       Test.HexagonSpec
       Test.IntegrationSpec
       Test.LevelSpec

--- a/src/Plunder/AI.hs
+++ b/src/Plunder/AI.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Enemy decision logic.
+--
+-- Pure: 'decideEnemy' inspects the board and the enemy's current memory and
+-- produces an 'EnemyAction'. State integration lives in "Plunder.State".
+module Plunder.AI
+  ( EnemyMind (..)
+  , defMind
+  , mind_lastSeen
+  , EnemyAction (..)
+  , sightRadius
+  , decideEnemy
+  ) where
+
+import           Control.Applicative ((<|>))
+import           Control.Lens
+import           Data.List           (sortOn)
+import qualified Data.Map.Strict     as Map
+import           Plunder.Combat      (unit_hp, Health)
+import           Plunder.Grid
+import           Plunder.Pathfinding (findPath)
+
+-- | What an enemy remembers between turns.  Currently just the last position
+-- a Player was spotted at; lets enemies pursue after the player breaks
+-- line-of-sight.
+--
+-- Decision: store memory in a separate 'Map Axial EnemyMind' on 'GameState'
+-- rather than extending the 'Enemy' 'TileContent' constructor.  The latter
+-- would have forced every existing test and Level codec to know about the
+-- new field; the map keeps the change contained to the AI subsystem.
+newtype EnemyMind = MkEnemyMind
+  { _mind_lastSeen :: Maybe Axial
+  } deriving (Show, Eq)
+
+defMind :: EnemyMind
+defMind = MkEnemyMind { _mind_lastSeen = Nothing }
+
+makeLenses ''EnemyMind
+
+-- | What 'decideEnemy' tells the caller to do this turn.  Positional fields
+-- keep all three constructors total (no partial selectors).
+data EnemyAction
+  = EAttack Axial Axial EnemyMind   -- ^ from, target, new mind
+  | EStep   Axial Axial EnemyMind   -- ^ from, one-tile step, new mind
+  | EIdle   Axial       EnemyMind   -- ^ from, new mind
+  deriving (Show, Eq)
+
+-- | How far an enemy can see (in hex distance).
+sightRadius :: Int
+sightRadius = 2
+
+-- | All Player axials on the board, paired with their HP (used to prefer
+-- weaker targets when several are equidistant).
+playersOnBoard :: Grid -> [(Axial, Health)]
+playersOnBoard grid =
+  [ (ax, u ^. unit_hp)
+  | (ax, tile) <- Map.toList grid
+  , Just (Player u) <- [tile ^. tile_content]
+  ]
+
+-- | Closest Player within 'sightRadius'.  Ties broken by lowest HP, then by
+-- 'Axial' order, so the decision is deterministic.
+spotPlayer :: Grid -> Axial -> Maybe Axial
+spotPlayer grid here =
+  let inSight = [ (ax, hp, hexDistance here ax)
+                | (ax, hp) <- playersOnBoard grid
+                , hexDistance here ax <= sightRadius
+                ]
+  in case sortOn (\(ax, hp, d) -> (d, hp, ax)) inSight of
+       []             -> Nothing
+       ((ax, _, _):_) -> Just ax
+
+-- | A Player on a tile directly adjacent to @here@, if any.  Same tie-breaking
+-- as 'spotPlayer' so attack target is deterministic.
+adjacentPlayer :: Grid -> Axial -> Maybe Axial
+adjacentPlayer grid here =
+  let candidates = [ (ax, hp)
+                   | ax <- neigbours here
+                   , Just tile <- [Map.lookup ax grid]
+                   , Just (Player u) <- [tile ^. tile_content]
+                   , let hp = u ^. unit_hp
+                   ]
+  in case sortOn (\(ax, hp) -> (hp, ax)) candidates of
+       []         -> Nothing
+       ((ax,_):_) -> Just ax
+
+-- | Decide what one enemy does this turn.
+--
+-- Rules, in order:
+--
+--   1. Adjacent Player ⇒ 'EAttack' it (prefer lowest HP).
+--   2. Player in sight ⇒ refresh memory, step one tile along BFS toward them.
+--   3. Stale memory of a Player ⇒ step one tile toward the remembered tile.
+--      The memory clears when the enemy reaches the spot, otherwise it
+--      keeps walking toward where the player last was.
+--   4. No sight, no memory ⇒ 'EIdle'.
+decideEnemy :: Grid -> Axial -> EnemyMind -> EnemyAction
+decideEnemy grid here oldMind =
+  let spotted    = spotPlayer grid here
+      remembered = spotted <|> _mind_lastSeen oldMind
+      clearedMind = case remembered of
+        Just t | t == here -> defMind
+        _                  -> MkEnemyMind { _mind_lastSeen = remembered }
+  in case adjacentPlayer grid here of
+       Just target -> EAttack here target clearedMind
+       Nothing -> case remembered of
+         Nothing     -> EIdle here clearedMind
+         Just target -> case findPath grid here target of
+           Just (next:_) -> EStep here next clearedMind
+           _             -> EIdle here clearedMind

--- a/src/Plunder/State.hs
+++ b/src/Plunder/State.hs
@@ -24,6 +24,7 @@ module Plunder.State(GameState(..)
             , game_camera
             , game_level_index
             , game_levels
+            , game_enemy_minds
             , inventory_money
             , inventroy_item
             , PlayerInventory(..)
@@ -45,6 +46,7 @@ module Plunder.State(GameState(..)
             ) where
 
 import qualified Control.Monad.State.Class as SC
+import           Plunder.AI                      (EnemyMind, EnemyAction(..), defMind, decideEnemy)
 import           Plunder.Combat
 import           Plunder.Level
 import           Control.Lens hiding (Level)
@@ -55,6 +57,7 @@ import           Control.Monad.Trans.Random.Lazy
 import           Control.Monad.Trans.State.Lazy  hiding (put)
 import           Data.Foldable
 import           Data.Functor.Compose
+import           Data.List                       (sort)
 import           Data.Monoid
 import           Data.Word
 import           Debug.Trace
@@ -70,7 +73,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Set(Set)
-import Data.Maybe(listToMaybe, mapMaybe, catMaybes)
+import Data.Maybe(listToMaybe, mapMaybe, catMaybes, fromMaybe)
 
 data GamePhase = Playing | YouDied | YouVictorious deriving (Show, Eq)
 
@@ -122,6 +125,7 @@ data GameState = MkGameState
   , _game_camera            :: V2 CInt           -- ^ pixel offset for camera panning
   , _game_level_index       :: Int               -- ^ which level we're currently on
   , _game_levels            :: [Level]           -- ^ immutable reference to all levels
+  , _game_enemy_minds       :: Map Axial EnemyMind -- ^ per-enemy AI memory, keyed by current tile
   } deriving (Show)
 makeLenses ''GameState
 makeLenses ''PlayerInventory
@@ -213,6 +217,7 @@ levelToGameState lvl =
         , _game_camera           = V2 0 0
         , _game_level_index      = 0
         , _game_levels           = []
+        , _game_enemy_minds      = Map.empty
         }
   in gs0 & game_explored .~ computeNewlyExplored gs0
   where
@@ -425,6 +430,55 @@ countLoot plan res =
    when (has (_MkAttack . attack_to . _House) plan) $
          game_player_inventory . inventory_money += 10
 
+-- | Run each living enemy in deterministic 'Axial' order.  Snapshotting the
+--   list up-front means a single enemy never acts twice in one turn even if
+--   another action shifts it; the per-step 'Nothing' guard skips enemies
+--   that the player already killed.
+runEnemies :: MonadRandom m => MonadState GameState m => m ()
+runEnemies = do
+  gs <- use id
+  let livingEnemies :: Set Axial
+      livingEnemies = Set.fromList
+        [ axial
+        | (axial, tile) <- Map.toList (gs ^. game_board)
+        , has (tile_content . _Just . _Enemy) tile
+        ]
+  game_enemy_minds %= Map.filterWithKey (\k _ -> Set.member k livingEnemies)
+  traverse_ stepEnemy (sort (Set.toList livingEnemies))
+
+-- | Resolve one enemy's chosen action.  Reads board state freshly so each
+--   enemy sees the consequences of earlier enemies' moves this turn.
+stepEnemy :: MonadRandom m => MonadState GameState m => Axial -> m ()
+stepEnemy src = do
+  gs <- use id
+  case gs ^? game_board . ix src . tile_content . _Just . _Enemy of
+    Nothing      -> pure ()
+    Just enemyU  -> do
+      let oldMind = fromMaybe defMind (gs ^. game_enemy_minds . at src)
+      case decideEnemy (gs ^. game_board) src oldMind of
+        EIdle _ newMind ->
+          game_enemy_minds . at src ?= newMind
+        EStep _ dst newMind -> do
+          let mv  = MkMove { _move_from = src, _move_to = dst, _move_from_unit = enemyU }
+              act = MkWalk mv
+          modifying game_board (figureOutMove Nothing act)
+          game_enemy_minds . at src .= Nothing
+          game_enemy_minds . at dst ?= newMind
+        EAttack _ dst newMind ->
+          case gs ^? game_board . ix dst . tile_content . _Just of
+            Nothing -> pure ()
+            Just tc -> do
+              let mv   = MkMove { _move_from = src, _move_to = dst, _move_from_unit = enemyU }
+                  plan = MkAttack (MkAttackMove { _attack_move = mv, _attack_to = tc })
+              mRes <- applyAttack plan
+              modifying game_board (figureOutMove mRes plan)
+              case mRes of
+                Just r | isTargetDead r -> do
+                  game_enemy_minds . at src .= Nothing
+                  game_enemy_minds . at dst ?= newMind
+                _ ->
+                  game_enemy_minds . at src ?= newMind
+
 -- | If a Player is selected, compute a BFS path to @towards@ (or return an
 --   empty path when @towards == selectedAxial@ to signal cancellation).
 --   Adjacent shops are handled immediately by the RightClick handler before
@@ -496,6 +550,7 @@ updateLogic = \case
                 MkWalk _  | not (null rest) -> pure (Just (dst, rest))
                 _                           -> pure Nothing
     game_planned_moves .= survivors
+    runEnemies
     game_selected .= Nothing
     updateExplored
   RightClick towards -> do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Test.Hspec
+import qualified Test.AISpec           as AISpec
 import qualified Test.HexagonSpec      as HexagonSpec
 import qualified Test.IntegrationSpec  as IntegrationSpec
 import qualified Test.LevelSpec        as LevelSpec
@@ -10,6 +11,7 @@ import qualified Test.StateSpec        as StateSpec
 
 main :: IO ()
 main = hspec $ do
+  describe "Test.AI"           AISpec.spec
   describe "Test.Hexagon"      HexagonSpec.spec
   describe "Test.Integration"  IntegrationSpec.spec
   describe "Test.Level"        LevelSpec.spec

--- a/test/Test/AISpec.hs
+++ b/test/Test/AISpec.hs
@@ -1,0 +1,177 @@
+module Test.AISpec (spec) where
+
+import           Control.Lens
+import           Control.Monad.Trans.Random.Lazy (runRandT)
+import qualified Data.Map.Strict                 as Map
+import           Plunder.AI                      (EnemyAction(..), EnemyMind(..), decideEnemy, defMind, mind_lastSeen, sightRadius)
+import           Plunder.Combat                  (Weapon(..), Unit, defUnit, unit_hp, unit_weapon)
+import           Plunder.Grid
+import           Plunder.State
+import           System.Random                   (mkStdGen)
+import           Test.Hspec
+
+-- | Run an event with a fixed RNG so combat damage is reproducible.
+runEvt :: UpdateEvts -> GameState -> GameState
+runEvt evt gs = updateState gs (rng, evt)
+  where rng = MkRandTNT (\inner -> fst <$> runRandT inner (mkStdGen 7))
+
+-- | A board with the standard 0..6 grid and nothing on it.
+emptyState :: GameState
+emptyState = initialState
+  & game_board %~ fmap clearTile
+  & game_enemy_minds .~ Map.empty
+  where
+    clearTile :: Tile -> Tile
+    clearTile t = t & tile_content .~ Nothing
+                    & tile_background .~ Nothing
+
+-- | An unarmed attacker deals no damage (see 'Plunder.Combat.getDmg').
+-- These tests want to observe combat outcomes, so units carry a weapon.
+armedUnit :: Unit
+armedUnit = defUnit & unit_weapon ?~ Sword
+
+-- | Place an armed Player at @ax@.
+withPlayer :: Axial -> GameState -> GameState
+withPlayer ax gs = gs & game_board . ix ax . tile_content ?~ Player armedUnit
+
+-- | Place an armed Enemy at @ax@.
+withEnemy :: Axial -> GameState -> GameState
+withEnemy ax gs = gs & game_board . ix ax . tile_content ?~ Enemy armedUnit
+
+-- | The single Player's HP, if there is one.
+firstPlayerHp :: GameState -> Maybe Int
+firstPlayerHp gs = gs ^? game_board . traversed
+                       . tile_content . _Just . _Player . unit_hp
+
+-- | Whether there is an Enemy on this tile.
+enemyAt :: Axial -> GameState -> Bool
+enemyAt ax gs = has (game_board . ix ax . tile_content . _Just . _Enemy) gs
+
+-- | All axials currently occupied by an Enemy.
+enemyPositions :: GameState -> [Axial]
+enemyPositions gs =
+  [ ax | (ax, t) <- Map.toList (gs ^. game_board)
+       , has (tile_content . _Just . _Enemy) t ]
+
+spec :: Spec
+spec = do
+ describe "decideEnemy (pure)" $ do
+  it "attacks an adjacent player" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 2 3)
+           & withEnemy  (MkAxial 3 3)
+    case decideEnemy (gs ^. game_board) (MkAxial 3 3) defMind of
+      EAttack _ to _ -> to `shouldBe` MkAxial 2 3
+      other -> expectationFailure $ "expected EAttack, got " <> show other
+
+  it "steps toward a player in sight (distance 2)" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 2 3)
+           & withEnemy  (MkAxial 4 3)   -- distance 2 from player
+    case decideEnemy (gs ^. game_board) (MkAxial 4 3) defMind of
+      EStep _ next mind -> do
+        hexDistance next (MkAxial 2 3) `shouldBe` 1
+        mind ^. mind_lastSeen `shouldBe` Just (MkAxial 2 3)
+      other -> expectationFailure $ "expected EStep, got " <> show other
+
+  it "is idle when no player is in sight and no memory" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 0 0)
+           & withEnemy  (MkAxial 6 6)   -- distance > sightRadius
+    case decideEnemy (gs ^. game_board) (MkAxial 6 6) defMind of
+      EIdle _ mind -> mind ^. mind_lastSeen `shouldBe` Nothing
+      other -> expectationFailure $ "expected EIdle, got " <> show other
+
+  it "pursues a remembered tile after losing sight" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 0 0)
+           & withEnemy  (MkAxial 6 6)
+        mind = MkEnemyMind { _mind_lastSeen = Just (MkAxial 5 5) }
+    case decideEnemy (gs ^. game_board) (MkAxial 6 6) mind of
+      EStep _ next _ -> hexDistance next (MkAxial 5 5) `shouldBe` 1
+      other -> expectationFailure $ "expected EStep toward remembered tile, got " <> show other
+
+  it "clears memory once the remembered tile is reached" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 0 0)
+           & withEnemy  (MkAxial 6 6)
+        mind = MkEnemyMind { _mind_lastSeen = Just (MkAxial 6 6) }
+    case decideEnemy (gs ^. game_board) (MkAxial 6 6) mind of
+      EIdle _ newMind -> newMind ^. mind_lastSeen `shouldBe` Nothing
+      other -> expectationFailure $ "expected EIdle after reaching last-seen tile, got " <> show other
+
+  it "sightRadius is 2" $
+    -- A change here would silently change AI behaviour; pin it.
+    sightRadius `shouldBe` 2
+
+ describe "runEnemies via EndTurn" $ do
+  it "adjacent enemy hits the player on EndTurn" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 2 3)
+           & withEnemy  (MkAxial 3 3)
+        afterTurn = runEvt EndTurn gs
+    firstPlayerHp afterTurn `shouldSatisfy` maybe False (< 10)
+
+  it "enemy 2 tiles away moves one step closer" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 2 3)
+           & withEnemy  (MkAxial 4 3)
+        afterTurn = runEvt EndTurn gs
+    enemyAt (MkAxial 4 3) afterTurn `shouldBe` False
+    case enemyPositions afterTurn of
+      [newPos] -> hexDistance newPos (MkAxial 2 3) `shouldBe` 1
+      other    -> expectationFailure $ "expected one enemy on board, got " <> show other
+
+  it "enemy out of sight and with no memory stays put" $ do
+    let enemyAxial = MkAxial 6 6
+        gs = emptyState
+           & withPlayer (MkAxial 0 0)
+           & withEnemy  enemyAxial
+        afterTurn = runEvt EndTurn gs
+    enemyAt enemyAxial afterTurn `shouldBe` True
+
+  it "enemy records lastSeen after stepping" $ do
+    let gs = emptyState
+           & withPlayer (MkAxial 2 3)
+           & withEnemy  (MkAxial 4 3)
+        afterTurn = runEvt EndTurn gs
+    case enemyPositions afterTurn of
+      [newPos] ->
+        afterTurn ^? game_enemy_minds . ix newPos . mind_lastSeen
+          `shouldBe` Just (Just (MkAxial 2 3))
+      other -> expectationFailure $ "expected one enemy on board, got " <> show other
+
+  it "two enemies don't both land on the same tile" $ do
+    -- Both enemies sit at distance 2 from the player and would naively step
+    -- onto the same tile.  The second one must re-path or stay put.
+    let gs = emptyState
+           & withPlayer (MkAxial 2 3)
+           & withEnemy  (MkAxial 4 3)
+           & withEnemy  (MkAxial 4 2)
+        afterTurn = runEvt EndTurn gs
+        positions = enemyPositions afterTurn
+    length positions `shouldBe` 2
+    length (Map.keys (Map.fromList (zip positions positions))) `shouldBe` 2
+
+  it "player killed by enemies triggers YouDied" $ do
+    -- Pre-wound the player to 1 HP and surround so combat finishes them.
+    let woundedPlayer = armedUnit & unit_hp .~ 1
+        gs = emptyState
+           & game_board . ix (MkAxial 2 3) . tile_content ?~ Player woundedPlayer
+           & withEnemy (MkAxial 3 3)
+           & withEnemy (MkAxial 2 4)
+           & withEnemy (MkAxial 3 2)
+        afterTurn = runEvt EndTurn gs
+    afterTurn ^. game_phase `shouldBe` YouDied
+
+  it "an enemy killed during the player phase doesn't act" $ do
+    -- Player attacks a weak enemy on EndTurn; that enemy must not also swing.
+    let weakEnemy = Enemy (defUnit & unit_hp .~ 1)
+        gs = emptyState
+           & withPlayer (MkAxial 2 3)
+           & game_board . ix (MkAxial 3 3) . tile_content ?~ weakEnemy
+           & game_selected .~ Just (MkAxial 2 3)
+        planned   = runEvt (RightClick (MkAxial 3 3)) gs
+        afterTurn = runEvt EndTurn planned
+    -- The dead enemy is gone (player walked onto its tile), so no mind entry remains.
+    afterTurn ^. game_enemy_minds . at (MkAxial 3 3) `shouldBe` Nothing


### PR DESCRIPTION
## Summary

- Enemies now act on `EndTurn`: attack adjacent players, step toward
  players in sight (radius 2 hex tiles), or pursue the last-known
  position when they lose line-of-sight.
- Per-enemy memory lives in a `Map Axial EnemyMind` on `GameState`. The
  decision keeps the change contained to the AI subsystem — `Enemy`
  `TileContent`, the level codec, render and existing tests are
  untouched.
- Combat reuses `applyAttack` and `figureOutMove` unchanged. Flanking
  already counts allies polymorphically, so enemy flanking comes for
  free.

This addresses the AI item on the Readme roadmap (line of sight 2 tiles
· spot player → mark + kill).

## Files

- `src/Plunder/AI.hs` (new) — pure `decideEnemy`, `EnemyMind`,
  `EnemyAction`.
- `src/Plunder/State.hs` — `_game_enemy_minds` field, `runEnemies`
  invocation inside `EndTurn` after the player phase.
- `test/Test/AISpec.hs` (new) — 13 specs covering both the pure
  decision function and the `EndTurn` integration.

## Test plan

- [x] `cabal test unit` — 224 examples, 0 failures (includes 13 new AI
  specs).
- [x] `cabal build all` — library and executable build clean; no new
  warnings introduced by this change.
- [ ] Manual playtest in the SDL window (cannot run from CI sandbox —
  please verify enemy behaviour feels right in-game before merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)